### PR TITLE
README: Clarify the purpose of linter/whitelists/default.txt

### DIFF
--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -55,7 +55,7 @@ und soll Angaben zur Installation und ggf. zum Erwerb eines Lizenzschlüssels et
 
 Die Metadaten werden automatisch auf korrekte Rechtschreibung überprüft. Wenn die Überprüfung fehlschlägt, du dir aber sicher bist, 
 dass das Wort korrekt ist, musst du womöglich die Whitelists aktualisieren. Diese werden im Ordner `linter/whitelists` nach Sprache 
-gepflegt. Eigennamen, die in jeder Sprache identisch sind, werden in `default.txt` gepflegt.
+gepflegt. Eigennamen und andere Begriffe, die in jeder Sprache identisch sind, werden in `default.txt` gepflegt.
 
 ## Unterstützte Sprachen
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -56,8 +56,8 @@ the package is required.
 
 Your meta data is automatically checked for spelling issues. You might need to update the whitelists in your
 pull request in case the spell check fails but you are sure the word you used is correct. The whitelists for each language
-are located in the folder `linter/whitelists`. For proper names which shouldn't change between different translations use the
- whitelist `default.txt`.
+are located in the folder `linter/whitelists`. For proper names and other terms that shouldn't change between different
+translations, use the whitelist `default.txt`.
 
 ## Supported languages
 


### PR DESCRIPTION
Do not limit cross-language terms to proper names.