### PR TITLE
Added dependency flag

### DIFF
--- a/linter/schema.json
+++ b/linter/schema.json
@@ -67,6 +67,10 @@
           "format": "uri"
         }
       }
+    },
+    "dependency": {
+      "type": "boolean",
+      "description": "If this package is a dependency. The package is only installable if it's a suggestion of an installed package."
     }
   },
   "additionalProperties": false

--- a/meta/codefog/contao-haste/en.yml
+++ b/meta/codefog/contao-haste/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-community-alliance/dc-general/en.yml
+++ b/meta/contao-community-alliance/dc-general/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-community-alliance/dependency-container/en.yml
+++ b/meta/contao-community-alliance/dependency-container/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-community-alliance/event-dispatcher/en.yml
+++ b/meta/contao-community-alliance/event-dispatcher/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-community-alliance/events-contao-bindings/en.yml
+++ b/meta/contao-community-alliance/events-contao-bindings/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/ace/en.yml
+++ b/meta/contao-components/ace/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/chosen/en.yml
+++ b/meta/contao-components/chosen/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/colorbox/en.yml
+++ b/meta/contao-components/colorbox/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/colorpicker/en.yml
+++ b/meta/contao-components/colorpicker/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/contao/en.yml
+++ b/meta/contao-components/contao/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/datepicker/en.yml
+++ b/meta/contao-components/datepicker/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/dropzone/en.yml
+++ b/meta/contao-components/dropzone/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/highlight/en.yml
+++ b/meta/contao-components/highlight/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/html5shiv/en.yml
+++ b/meta/contao-components/html5shiv/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/jquery-ui/en.yml
+++ b/meta/contao-components/jquery-ui/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/jquery/en.yml
+++ b/meta/contao-components/jquery/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/mediabox/en.yml
+++ b/meta/contao-components/mediabox/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/mootools/en.yml
+++ b/meta/contao-components/mootools/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/respimage/en.yml
+++ b/meta/contao-components/respimage/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/simplemodal/en.yml
+++ b/meta/contao-components/simplemodal/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/stylect/en.yml
+++ b/meta/contao-components/stylect/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/swipe/en.yml
+++ b/meta/contao-components/swipe/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/tablesort/en.yml
+++ b/meta/contao-components/tablesort/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/tablesorter/en.yml
+++ b/meta/contao-components/tablesorter/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao-components/tinymce4/en.yml
+++ b/meta/contao-components/tinymce4/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao/core-bundle/en.yml
+++ b/meta/contao/core-bundle/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/contao/manager-bundle/en.yml
+++ b/meta/contao/manager-bundle/en.yml
@@ -1,3 +1,4 @@
 en:
     title: Contao Open Source CMS
     description: Contao is a powerful open source CMS that allows you to create professional websites and scalable web applications.
+    dependency: true

--- a/meta/contao/skeleton-bundle/en.yml
+++ b/meta/contao/skeleton-bundle/en.yml
@@ -1,0 +1,2 @@
+en:
+    dependency: true

--- a/meta/terminal42/dc_multilingual/de.yml
+++ b/meta/terminal42/dc_multilingual/de.yml
@@ -8,3 +8,4 @@ de:
         - Navigation
         - SEO
         - Alias
+    dependency: true

--- a/meta/terminal42/dc_multilingual/en.yml
+++ b/meta/terminal42/dc_multilingual/en.yml
@@ -9,3 +9,4 @@ en:
         - navigation
         - alias
         - seo
+    dependency: true


### PR DESCRIPTION
By default, all packages in this metadata repository will show up in search results, and they are installable in a regular Contao setup. However, that does not always make sense.

Dependencies are packages that should have metadata (translations) but are not searchable and not installable (except if they are a suggestion of an installed package). Examples can be any suggested library (e.g. `phpoffice/phpexcel`) or also packages of type `contao-module` but are actually developer libraries (e.g. `codefog/contao-haste`).