### PR TITLE
Add "allowed syntax" section to documentation

### DIFF
--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -52,7 +52,7 @@ In der YAML-Datei können die folgenden Keywörter definiert werden:
 | __title__       | Der Titel der Erweiterung | 
 | __description__ | Lange Beschreibung der Extension, die in der Detailansicht erscheint | 
 | __keywords__    | Liste von Keywörtern für die Suche | 
-| __dependency__  | Bei `true` wird die Extension nicht über die Suche gefunden. Dies ist der Fall für Extensions, die nicht für den Endnutzer gedacht sind (Standaard: false) | 
+| __dependency__  | Bei `true` wird die Extension nicht über die Suche gefunden. Dies ist der Fall für Extensions, die nicht für den Endnutzer gedacht sind (Standard: `false`) | 
 
 ## Öffentliche vs. private/proprietäre Pakete
 

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -23,7 +23,7 @@ meta/[vendor]/[paket-name]
 Hinweis: Das `logo.svg` kann auch direkt innerhalb von `[vendor]` liegen, es wird dann als Fallback für alle Pakete
 dieses `[vendor]` verwendet, sofern kein Logo für das explizite Paket angegeben wurde.
 
-## Beispiel einer YAML Sprachdatei
+## Beispiel einer YAML-Sprachdatei
 
 ```
 de:
@@ -42,6 +42,17 @@ de:
 
 Bitte verwendet 4 Leerzeichen zum Einrücken oder Verschachteln und sprecht den Nutzer mit "du" an.
 Für weitere Informationen zum Dateiformat, sieh dir die [Transifex Dokumentation][2] an.
+
+## YAML-Syntax
+
+In der YAML-Datei können die folgenden Keywörter definiert werden: 
+
+| | | 
+|-|-| 
+| __title__       | Der Titel der Erweiterung | 
+| __description__ | Lange Beschreibung der Extension, die in der Detailansicht erscheint | 
+| __keywords__    | Liste von Keywörtern für die Suche | 
+| __dependency__  | Bei `true` wird die Extension nicht über die Suche gefunden. Dies ist der Fall für Extensions, die nicht für den Endnutzer gedacht sind (Standaard: false) | 
 
 ## Öffentliche vs. private/proprietäre Pakete
 

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -18,6 +18,7 @@ meta/[vendor]/[paket-name]
     - ru.yml
     - ...
     - logo.svg (optional)
+    - composer.json (nur für private Pakete und optional. [Details](#öffentliche-vs-privateproprietäre-pakete))
 ```
 
 Hinweis: Das `logo.svg` kann auch direkt innerhalb von `[vendor]` liegen, es wird dann als Fallback für alle Pakete
@@ -65,6 +66,11 @@ nach privaten bzw. proprietären Paketen. Entsprechend kannst du für beide Pake
 Definition eines öffentlichen Pakets ist dessen Verfügbarkeit via [packagist.org][5]. Für private Pakete bietet der 
 Contao Manager aktuell noch keinen automatisierten Installationsprozess. Deshalb ist eine "homepage" Pflichtangabe
 und soll Angaben zur Installation und ggf. zum Erwerb eines Lizenzschlüssels etc. enthalten.
+
+Der Contao Manager zeigt für jedes Paket hilfreiche Informationen an, darunter eine Auflistung von Abhängigkeiten des
+Pakets. Diese Informationen werden über die `composer.json` bereitgestellt und sind aufgrund dessen nur für öffentliche
+Pakete verfügbar. Um diese Informationen für private Pakete bereitzustellen, kann den Metadaten eine `composer.json` ergänzt
+werden.
 
 ## Rechtschreibprüfung
 

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -38,6 +38,9 @@ de:
       - lorem ipsum
       - keyword2
       ...
+    support:
+        issues: https://github.com/demo/demo/issues
+        docs: https://example.org/demo/de/docs
 ```
 
 Bitte verwendet 4 Leerzeichen zum Einrücken oder Verschachteln und sprecht den Nutzer mit "du" an.
@@ -53,6 +56,7 @@ In der YAML-Datei können die folgenden Keywörter definiert werden:
 | __description__ | Lange Beschreibung der Extension, die in der Detailansicht erscheint | 
 | __keywords__    | Liste von Keywörtern für die Suche | 
 | __dependency__  | Bei `true` wird die Extension nicht über die Suche gefunden. Dies ist der Fall für Extensions, die nicht für den Endnutzer gedacht sind (Standard: `false`) | 
+| __support__     | Übersetzung bzw. Angabe von sprach-spezifischen Support-Links der `composer.json`. Key-Value-Syntax: [Unterstützte Keys][8] | 
 
 ## Öffentliche vs. private/proprietäre Pakete
 
@@ -88,3 +92,4 @@ Siehe https://github.com/contao/contao-manager/blob/master/src/i18n/locales.js
 [5]: https://packagist.org
 [6]: https://github.com/svg/svgo
 [7]: https://jakearchibald.github.io/svgomg/
+[8]: https://getcomposer.org/doc/04-schema.md#support

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -42,6 +42,8 @@ de:
     support:
         issues: https://github.com/demo/demo/issues
         docs: https://example.org/demo/de/docs
+    suggest:
+        vendor/package: Dieses Package ermöglicht XLSX-Export
 ```
 
 Bitte verwendet 4 Leerzeichen zum Einrücken oder Verschachteln und sprecht den Nutzer mit "du" an.
@@ -58,6 +60,7 @@ In der YAML-Datei können die folgenden Keywörter definiert werden:
 | __keywords__    | Liste von Keywörtern für die Suche | 
 | __dependency__  | Bei `true` wird die Extension nicht über die Suche gefunden. Dies ist der Fall für Extensions, die nicht für Anwendende gedacht sind (Standard: `false`) | 
 | __support__     | Übersetzung bzw. Angabe von sprach-spezifischen Support-Links der `composer.json`. Key-Value-Syntax: [Unterstützte Keys][8] | 
+| __suggest__     | Übersetzung der Texte für empfohlene Pakete (`suggest`-Abschnitt) | 
 
 ## Öffentliche vs. private/proprietäre Pakete
 

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -56,7 +56,7 @@ In der YAML-Datei können die folgenden Keywörter definiert werden:
 | __title__       | Der Titel der Erweiterung | 
 | __description__ | Lange Beschreibung der Extension, die in der Detailansicht erscheint | 
 | __keywords__    | Liste von Keywörtern für die Suche | 
-| __dependency__  | Bei `true` wird die Extension nicht über die Suche gefunden. Dies ist der Fall für Extensions, die nicht für den Endnutzer gedacht sind (Standard: `false`) | 
+| __dependency__  | Bei `true` wird die Extension nicht über die Suche gefunden. Dies ist der Fall für Extensions, die nicht für Anwendende gedacht sind (Standard: `false`) | 
 | __support__     | Übersetzung bzw. Angabe von sprach-spezifischen Support-Links der `composer.json`. Key-Value-Syntax: [Unterstützte Keys][8] | 
 
 ## Öffentliche vs. private/proprietäre Pakete

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -41,7 +41,9 @@ en:
         ...
     support:
         issues: https://github.com/demo/demo/issues
-        docs: https://example.org/demo/docs
+        docs: https://example.org/demo/
+    suggest:
+        vendor/package: This package allows you to export XLSX files
 ```
 
 
@@ -59,6 +61,7 @@ The following keywords can be defined in the meta data yaml file:
 | __keywords__    | List of keywords that will enhance search performance  | 
 | __dependency__  | If true, the extension will not show up in the search. This is useful for extensions not tailored for end-users (default: `false`) | 
 | __support__     | Allows you to provide differing support links for certain languages that originally are part of the `composer.json`. Key-value syntax: [supported keys][8] | 
+| __suggest__     | Provide translation of the texts within the `suggest` section | 
 
 ## Public vs. private/proprietary packages
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -38,6 +38,9 @@ en:
         - lorem ipsum
         - keyword2
         ...
+    support:
+        issues: https://github.com/demo/demo/issues
+        docs: https://example.org/demo/docs
 ```
 
 
@@ -54,6 +57,7 @@ The following keywords can be defined in the meta data yaml file:
 | __description__ | Long description of the extension that shows up in the Details view | 
 | __keywords__    | List of keywords that will enhance search performance  | 
 | __dependency__  | If true, the extension will not show up in the search. This is useful for extensions not tailored for end-users (default: `false`) | 
+| __support__     | Allows you to provide differing support links for certain languages that originally are part of the `composer.json`. Key-value syntax: [supported keys][8] | 
 
 ## Public vs. private/proprietary packages
 
@@ -90,3 +94,4 @@ See https://github.com/contao/contao-manager/blob/master/src/i18n/locales.js
 [5]: https://packagist.org
 [6]: https://github.com/svg/svgo
 [7]: https://jakearchibald.github.io/svgomg/
+[8]: https://getcomposer.org/doc/04-schema.md#support

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -44,6 +44,17 @@ en:
 Please use 4 spaces for indentation or nesting.
 For more information on the file format, see [the Transifex documentation][2]
 
+## YAML syntax
+
+The following keywords can be defined in the meta data yaml file:
+
+| | | 
+|-|-| 
+| __title__       | Title of the extension | 
+| __description__ | Long description of the extension that shows up in the Details view | 
+| __keywords__    | List of keywords that will enhance search performance  | 
+| __dependency__  | If true, the extension will not show up in the search. This is useful for extensions not tailored for end-users (default: false) | 
+
 ## Public vs. private/proprietary packages
 
 The metadata repository feeds the Contao Manager search index and as such allows to search for both, publicly available

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -53,7 +53,7 @@ The following keywords can be defined in the meta data yaml file:
 | __title__       | Title of the extension | 
 | __description__ | Long description of the extension that shows up in the Details view | 
 | __keywords__    | List of keywords that will enhance search performance  | 
-| __dependency__  | If true, the extension will not show up in the search. This is useful for extensions not tailored for end-users (default: false) | 
+| __dependency__  | If true, the extension will not show up in the search. This is useful for extensions not tailored for end-users (default: `false`) | 
 
 ## Public vs. private/proprietary packages
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -18,6 +18,7 @@ meta/[vendor]/[package]
     - ru.yml
     - ...
     - logo.svg (optional)
+    - composer.json (only for private packages and optional. [Details](#public-vs-privateproprietary-packages))
 ```
 
 Hint: The `logo.svg` can also be place directly within `[vendor]`. It is then used as a fallback logo for all packages of
@@ -66,6 +67,10 @@ or private/proprietary packages. You are allowed to submit any package descripti
 package is the fact that it's registered on [packagist.org][5]. For private packages, the Contao Manager does currently
 not provide any automated installation process so providing a homepage link to describe how a user can obtain and install
 the package is required.
+
+The Contao Manager shows meaningful information for all packages, for example, a list of requirements. This information is
+provided by the `composer.json` and thus is only available for public packages. To add this information for private
+packages, you can add a `composer.json` to your metadata.
 
 ## Spell checking
 


### PR DESCRIPTION
I started documenting the allowed yaml syntax.

When parsed, the table will look like:

<img width="895" alt="Screen Shot 2019-10-04 at 10 30 06" src="https://user-images.githubusercontent.com/1284725/66174889-3167a300-e692-11e9-83eb-27e128474b4c.png">
