### PR TITLE
Mark extensions as dependecy

### DIFF
--- a/meta/craffft/api-client-bundle/de.yml
+++ b/meta/craffft/api-client-bundle/de.yml
@@ -7,3 +7,4 @@ de:
         - client
         - token
         - authentication
+    dependency: true

--- a/meta/craffft/api-client-bundle/en.yml
+++ b/meta/craffft/api-client-bundle/en.yml
@@ -7,3 +7,4 @@ en:
         - client
         - token
         - authentication
+    dependency: true

--- a/meta/craffft/barqrcodewizard-bundle/de.yml
+++ b/meta/craffft/barqrcodewizard-bundle/de.yml
@@ -6,3 +6,4 @@ de:
         - qr-code
         - barcode
         - wizard
+    dependency: true

--- a/meta/craffft/barqrcodewizard-bundle/en.yml
+++ b/meta/craffft/barqrcodewizard-bundle/en.yml
@@ -6,3 +6,4 @@ en:
         - qr-code
         - barcode
         - wizard
+    dependency: true

--- a/meta/craffft/contao-oauth2-bundle/de.yml
+++ b/meta/craffft/contao-oauth2-bundle/de.yml
@@ -6,3 +6,4 @@ de:
         - oauth
         - authentication
         - security
+    dependency: true

--- a/meta/craffft/contao-oauth2-bundle/en.yml
+++ b/meta/craffft/contao-oauth2-bundle/en.yml
@@ -6,3 +6,4 @@ en:
         - oauth
         - authentication
         - security
+    dependency: true

--- a/meta/craffft/crosstabs-bundle/de.yml
+++ b/meta/craffft/crosstabs-bundle/de.yml
@@ -6,3 +6,4 @@ de:
         - crosstabs
         - table
         - relation
+    dependency: true

--- a/meta/craffft/crosstabs-bundle/en.yml
+++ b/meta/craffft/crosstabs-bundle/en.yml
@@ -6,3 +6,4 @@ en:
         - crosstabs
         - table
         - relation
+    dependency: true

--- a/meta/craffft/currencies-bundle/de.yml
+++ b/meta/craffft/currencies-bundle/de.yml
@@ -6,3 +6,4 @@ de:
         - currency
         - money
         - wizard
+    dependency: true

--- a/meta/craffft/currencies-bundle/en.yml
+++ b/meta/craffft/currencies-bundle/en.yml
@@ -6,3 +6,4 @@ en:
         - currency
         - money
         - wizard
+    dependency: true

--- a/meta/craffft/single-session-storage-bundle/de.yml
+++ b/meta/craffft/single-session-storage-bundle/de.yml
@@ -6,3 +6,4 @@ de:
         - storage
         - session
         - server-side
+    dependency: true

--- a/meta/craffft/single-session-storage-bundle/en.yml
+++ b/meta/craffft/single-session-storage-bundle/en.yml
@@ -6,3 +6,4 @@ en:
         - storage
         - session
         - server-side
+    dependency: true

--- a/meta/craffft/translation-fields-bundle/de.yml
+++ b/meta/craffft/translation-fields-bundle/de.yml
@@ -6,3 +6,4 @@ de:
         - translation
         - i18n
         - fields
+    dependency: true

--- a/meta/craffft/translation-fields-bundle/en.yml
+++ b/meta/craffft/translation-fields-bundle/en.yml
@@ -6,3 +6,4 @@ en:
         - translation
         - i18n
         - fields
+    dependency: true


### PR DESCRIPTION
Mark some extensions as dependency, so that they are not visible for end-users. 

See https://community.contao.org/de/showthread.php?76361-Barcode