### PR TITLE
Allow the linter to check only one file

### DIFF
--- a/linter/lint
+++ b/linter/lint
@@ -7,9 +7,13 @@ require __DIR__.'/vendor/autoload.php';
 use Symfony\Component\Console\Application;
 use Contao\PackageMetaDataLinter\LintCommand;
 
+ini_set('display_errors', '1');
+ini_set('display_startup_errors', '1');
+error_reporting(E_ALL);
+
 $lintCommand = new LintCommand();
 
 $application = new Application();
 $application->add($lintCommand);
-$application->setDefaultCommand($lintCommand->getName());
+$application->setDefaultCommand($lintCommand->getName(), true);
 $application->run();

--- a/linter/src/LintCommand.php
+++ b/linter/src/LintCommand.php
@@ -17,6 +17,8 @@ use JsonSchema\Constraints\Constraint;
 use JsonSchema\Exception\ValidationException;
 use JsonSchema\Validator;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -47,6 +49,7 @@ class LintCommand extends Command
         $this
             ->setName('app:lint')
             ->setDescription('Lint all the metadata.')
+            ->addArgument('files', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'To lint specific files')
             ->addOption('skip-private-check', null, InputOption::VALUE_NONE, 'Do not check packagist if a package is private.')
         ;
     }
@@ -55,6 +58,12 @@ class LintCommand extends Command
     {
         $this->io = new SymfonyStyle($input, $output);
         $this->io->title('Contao Package metadata linter');
+
+        if ($files = $input->getArgument('files')) {
+            $this->validateFiles($files, $input->getOption('skip-private-check'));
+
+            return $this->error ? 1 : 0;
+        }
 
         $this->validateMetadata($input->getOption('skip-private-check'));
         $this->validateComposerJson();
@@ -66,10 +75,27 @@ class LintCommand extends Command
         return $this->error ? 1 : 0;
     }
 
+    private function validateFiles(array $files, $skipPrivate)
+    {
+        foreach ($files as $path) {
+            $file = new \SplFileInfo(realpath($path));
+
+            if (!$file->isFile()) {
+                $this->io->error(sprintf('The file "%s" was not found', $path));
+                $this->error = true;
+                continue;
+            }
+
+            if ($file->getFilename() === 'composer.json') {
+                $this->validateComposerFile($file);
+            } else {
+                $this->validateMetadataFile($file, $skipPrivate);
+            }
+        }
+    }
+
     private function validateMetadata(bool $skipPrivate)
     {
-        $this->spellChecker = new SpellChecker(__DIR__.'/../whitelists');
-
         $finder = new Finder();
         $finder->files()->in(__DIR__.'/../../meta')->depth('== 2')->name('*.{yaml,yml}');
 
@@ -77,47 +103,60 @@ class LintCommand extends Command
         $this->io->progressStart($finder->count());
 
         foreach ($finder as $file) {
-            $package = basename(\dirname($file->getPath())).'/'.basename($file->getPath());
-            $language = str_replace(['.yaml', '.yml'], '', $file->getBasename());
-
-            $content = file_get_contents($file->getPath().'/'.$file->getFilename());
-
-            $this->io->progressAdvance();
-
-            // Line ending
-            if (!("\n" === substr($content, -1) && "\n" !== substr($content, -2))) {
-                $this->error($package, $language, 'File must end by a singe new line.');
-                continue;
-            }
-
-            try {
-                $content = Yaml::parse($content);
-            } catch (ParseException $e) {
-                $this->error($package, $language, 'The YAML file is invalid');
-                continue;
-            }
-
-            // Language
-            if (!isset($content[$language])) {
-                $this->error($package, $language, 'The language key in the YAML file does not match the specified language file name.');
-                continue;
-            }
-
-            // Validate for private package
-            if ($skipPrivate) {
-                $requiresHomepage = false;
-            } else {
-                $requiresHomepage = !file_exists($file->getPath().'/composer.json') && $this->isPrivatePackage($package);
-            }
-
-            // Content
-            if (!$this->validateContent($package, $language, $content[$language], $requiresHomepage)) {
-                $this->error($package, $language, 'The YAML file contains invalid data.');
-                continue;
-            }
+            $this->validateMetadataFile($file, $skipPrivate);
         }
 
         $this->io->progressFinish();
+    }
+
+    private function validateMetadataFile(\SplFileInfo $file, bool $skipPrivate)
+    {
+        if (null === $this->spellChecker) {
+            $this->spellChecker = new SpellChecker(__DIR__.'/../whitelists');
+        }
+
+        $package = basename(\dirname($file->getPath())).'/'.basename($file->getPath());
+        $language = str_replace(['.yaml', '.yml'], '', $file->getBasename());
+
+        $content = file_get_contents($file->getPath().'/'.$file->getFilename());
+
+        try {
+            $this->io->progressAdvance();
+        } catch (RuntimeException $e) {
+            // ignore no progress bar
+        }
+
+        // Line ending
+        if (!("\n" === substr($content, -1) && "\n" !== substr($content, -2))) {
+            $this->error($package, $language, 'File must end by a singe new line.');
+            return;
+        }
+
+        try {
+            $content = Yaml::parse($content);
+        } catch (ParseException $e) {
+            $this->error($package, $language, 'The YAML file is invalid');
+            return;
+        }
+
+        // Language
+        if (!isset($content[$language])) {
+            $this->error($package, $language, 'The language key in the YAML file does not match the specified language file name.');
+            return;
+        }
+
+        // Validate for private package
+        if ($skipPrivate) {
+            $requiresHomepage = false;
+        } else {
+            $requiresHomepage = !file_exists($file->getPath().'/composer.json') && $this->isPrivatePackage($package);
+        }
+
+        // Content
+        if (!$this->validateContent($package, $language, $content[$language], $requiresHomepage)) {
+            $this->error($package, $language, 'The YAML file contains invalid data.');
+            return;
+        }
     }
 
     private function validateComposerJson()
@@ -129,30 +168,39 @@ class LintCommand extends Command
         $this->io->progressStart($finder->count());
 
         foreach ($finder as $file) {
-            $package = basename(\dirname($file->getPath())).'/'.basename($file->getPath());
-
-            try {
-                $schemaFile = 'file://'.__DIR__.'/../vendor/composer/composer/res/composer-schema.json';
-                $schema = (object) ['$ref' => $schemaFile];
-                $schema->required = ['name', 'homepage'];
-
-                $value = json_decode(file_get_contents($file->getPathname()), false);
-                $validator = new Validator();
-                $validator->validate($value, $schema, Constraint::CHECK_MODE_EXCEPTIONS);
-
-                if ($value->name !== $package) {
-                    $this->error = true;
-                    $this->io->error(sprintf('[Package: %s] Package name in composer.json does not match', $package));
-                }
-            } catch (ValidationException $e) {
-                $this->error = true;
-                $this->io->error(sprintf('[Package: %s] Error in composer.json: %s', $package, $e->getMessage()));
-            }
-
-            $this->io->progressAdvance();
+            $this->validateComposerFile($file);
         }
 
         $this->io->progressFinish();
+    }
+
+    private function validateComposerFile(\SplFileInfo $file)
+    {
+        $package = basename(\dirname($file->getPath())).'/'.basename($file->getPath());
+
+        try {
+            $schemaFile = 'file://'.__DIR__.'/../vendor/composer/composer/res/composer-schema.json';
+            $schema = (object) ['$ref' => $schemaFile];
+            $schema->required = ['name', 'homepage'];
+
+            $value = json_decode(file_get_contents($file->getPathname()), false);
+            $validator = new Validator();
+            $validator->validate($value, $schema, Constraint::CHECK_MODE_EXCEPTIONS);
+
+            if ($value->name !== $package) {
+                $this->error = true;
+                $this->io->error(sprintf('[Package: %s] Package name in composer.json does not match', $package));
+            }
+        } catch (ValidationException $e) {
+            $this->error = true;
+            $this->io->error(sprintf('[Package: %s] Error in composer.json: %s', $package, $e->getMessage()));
+        }
+
+        try {
+            $this->io->progressAdvance();
+        } catch (RuntimeException $e) {
+            // ignore no progress bar
+        }
     }
 
     private function isPrivatePackage(string $package): bool


### PR DESCRIPTION
This can be used in a git `pre-commit` file to lint the changed files.

FYI here's what my file looks like

```sh
#!/bin/sh

if git rev-parse --verify HEAD >/dev/null 2>&1; then
    against=HEAD
else
    # Initial commit: diff against an empty tree object
    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
fi

for FILE in `git diff-index --name-status $against -- | cut -c3-` ; do

    if [[ $FILE =~ (\.yml|composer\.json)$ ]];
    then
        exec ./linter/lint $FILE || exit 1
    fi
done


```