### PR TITLE
Move package-indexer to metadata repository

### DIFF
--- a/.github/workflows/index.yaml
+++ b/.github/workflows/index.yaml
@@ -1,0 +1,49 @@
+name: Index Contao Package Metadata
+
+on:
+    push:
+#        branches:
+#            - master
+#        paths:
+#            - 'meta/*'
+#    schedule:
+#        - cron: '*/30 * * * *'
+
+jobs:
+    index:
+        runs-on: ubuntu-latest
+#        if: github.event_name != 'schedule'
+        steps:
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v1
+              with:
+                  php-version: 7.3
+                  extensions: json
+                  tools: prestissimo
+                  coverage: none
+
+            - name: Checkout
+              uses: actions/checkout@@v2
+
+            - uses: actions/cache@v1
+              with:
+                  path: vendor/
+                  key: ${{ runner.os }}-composer-vendor
+                  restore-keys: |
+                      ${{ runner.os }}-composer-vendor
+
+            - uses: actions/cache@v1
+              id: cache-files
+              with:
+                  path: cache/
+                  key: ${{ runner.os }}-cache-files
+
+            - name: Install the dependencies
+              run: composer install --no-interaction --no-suggest
+
+            - name: Run Indexer
+              run: indexer/index
+              env:
+                  ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+                  ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+                  ALGOLIA_INDEX: v3_test

--- a/.github/workflows/index.yaml
+++ b/.github/workflows/index.yaml
@@ -1,18 +1,17 @@
-name: Index Contao Package Metadata
+name: Update Package Metadata Index
 
 on:
-    push:
+#    push:
 #        branches:
 #            - master
 #        paths:
 #            - 'meta/*'
-#    schedule:
-#        - cron: '*/30 * * * *'
+    schedule:
+        - cron: '*/30 * * * *'
 
 jobs:
     index:
         runs-on: ubuntu-latest
-#        if: github.event_name != 'schedule'
         steps:
             - name: Setup PHP
               uses: shivammathur/setup-php@v1
@@ -20,30 +19,32 @@ jobs:
                   php-version: 7.3
                   extensions: json
                   tools: prestissimo
-                  coverage: none
 
             - name: Checkout
-              uses: actions/checkout@@v2
+              uses: actions/checkout@v2
 
             - uses: actions/cache@v1
               with:
-                  path: vendor/
+                  path: indexer/vendor/
                   key: ${{ runner.os }}-composer-vendor
-                  restore-keys: |
-                      ${{ runner.os }}-composer-vendor
 
             - uses: actions/cache@v1
               id: cache-files
               with:
-                  path: cache/
+                  path: indexer/cache/
                   key: ${{ runner.os }}-cache-files
 
             - name: Install the dependencies
-              run: composer install --no-interaction --no-suggest
+              run: cd indexer && composer install --no-interaction --no-suggest
 
-            - name: Run Indexer
-              run: indexer/index
+            # Update statistics twice a day (24 * 30 mins = 12h)
+            - name: with-stats
+              run: |
+                  echo "::set-env name=with_stats::$(expr ${{ github.run_number }} % 24)"
+
+            - name: Update Index
+              run: indexer/index ${{ env.with_stats == 0 && '--with-stats' || '' }}
               env:
                   ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
                   ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
-                  ALGOLIA_INDEX: v3_test
+                  ALGOLIA_INDEX: v3_packages

--- a/indexer/.gitignore
+++ b/indexer/.gitignore
@@ -1,0 +1,3 @@
+/cache/
+/vendor/
+/.php_cs.cache

--- a/indexer/.php_cs.dist
+++ b/indexer/.php_cs.dist
@@ -1,0 +1,43 @@
+<?php
+
+$date = date('Y');
+
+$header = <<<EOF
+Contao Package Indexer
+
+@author     Yanick Witschi <yanick.witschi@terminal42.ch>
+@author     Andreas Schempp <andreas.schempp@terminal42.ch>
+@license    MIT
+EOF;
+
+return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+            '@Symfony' => true,
+            '@Symfony:risky' => true,
+            'array_syntax' => array('syntax' => 'short'),
+            'combine_consecutive_unsets' => true,
+            'declare_strict_types' => true,
+            // one should use PHPUnit methods to set up expected exception instead of annotations
+            'general_phpdoc_annotation_remove' => array('expectedException', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp'),
+            'header_comment' => array('header' => $header),
+            'heredoc_to_nowdoc' => true,
+            'no_extra_consecutive_blank_lines' => array('break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block'),
+            'no_unreachable_default_argument_value' => true,
+            'no_useless_else' => true,
+            'no_useless_return' => true,
+            'no_superfluous_phpdoc_tags' => true,
+            'ordered_class_elements' => true,
+            'ordered_imports' => true,
+            'php_unit_strict' => true,
+            'phpdoc_add_missing_param_annotation' => true,
+            'phpdoc_order' => true,
+            'psr4' => true,
+            'strict_comparison' => true,
+            'strict_param' => true,
+            'native_function_invocation' => ['include' => ['@compiler_optimized']],
+    ])
+    ->setFinder(
+        PhpCsFixer\Finder::create()->in([__DIR__.'/src'])
+    )
+;

--- a/indexer/.php_cs.dist
+++ b/indexer/.php_cs.dist
@@ -10,34 +10,10 @@ Contao Package Indexer
 @license    MIT
 EOF;
 
-return PhpCsFixer\Config::create()
-    ->setRiskyAllowed(true)
-    ->setRules([
-            '@Symfony' => true,
-            '@Symfony:risky' => true,
-            'array_syntax' => array('syntax' => 'short'),
-            'combine_consecutive_unsets' => true,
-            'declare_strict_types' => true,
-            // one should use PHPUnit methods to set up expected exception instead of annotations
-            'general_phpdoc_annotation_remove' => array('expectedException', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp'),
-            'header_comment' => array('header' => $header),
-            'heredoc_to_nowdoc' => true,
-            'no_extra_consecutive_blank_lines' => array('break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block'),
-            'no_unreachable_default_argument_value' => true,
-            'no_useless_else' => true,
-            'no_useless_return' => true,
-            'no_superfluous_phpdoc_tags' => true,
-            'ordered_class_elements' => true,
-            'ordered_imports' => true,
-            'php_unit_strict' => true,
-            'phpdoc_add_missing_param_annotation' => true,
-            'phpdoc_order' => true,
-            'psr4' => true,
-            'strict_comparison' => true,
-            'strict_param' => true,
-            'native_function_invocation' => ['include' => ['@compiler_optimized']],
-    ])
-    ->setFinder(
-        PhpCsFixer\Finder::create()->in([__DIR__.'/src'])
-    )
+$config = new Contao\PhpCsFixer\DefaultConfig($header);
+$config
+    ->getFinder()
+    ->in(__DIR__.'/src')
 ;
+
+return $config;

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -1,0 +1,23 @@
+# Contao Package Indexer
+
+The *Contao Package Indexer* is a Symfony console application that
+pushes information about Composer packages to [Algolia]. Algolia is then
+used by the [Contao Manager] to search for packages.
+
+**This application is for internal use only and should not**
+**be used by anyone but the Contao core team.**
+
+
+## Setup & Run
+
+The application requires three environment variables to run:
+
+ 1. `ALGOLIA_APP_ID` is your Algolia application ID
+ 2. `ALGOLIA_API_KEY` is your Algolia API key
+ 2. `ALGOLIA_INDEX` is the name of your Algolia index
+
+Next you can simply run the `index` file in your command line.
+
+
+[Algolia]: https://www.algolia.com
+[Contao Manager]: https://github.com/contao/contao-manager

--- a/indexer/composer.json
+++ b/indexer/composer.json
@@ -6,8 +6,6 @@
     "keywords": ["contao", "manager", "composer", "packages", "algolia", "search"],
     "require": {
         "php": "^7.3",
-        "ext-ctype": "*",
-        "ext-iconv": "*",
         "ext-json": "*",
         "algolia/algoliasearch-client-php": "^1.27",
         "symfony/cache": "^5.0",

--- a/indexer/composer.json
+++ b/indexer/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "contao/package-metadata-indexer",
+    "description": "An indexer for the package meta data",
+    "type": "project",
+    "license": "MIT",
+    "keywords": ["contao", "manager", "composer", "packages", "algolia", "search"],
+    "require": {
+        "php": "^7.3",
+        "ext-ctype": "*",
+        "ext-iconv": "*",
+        "ext-json": "*",
+        "algolia/algoliasearch-client-php": "^1.27",
+        "symfony/cache": "^5.0",
+        "symfony/console": "^5.0",
+        "symfony/finder": "^5.0",
+        "symfony/http-client": "^5.0",
+        "symfony/http-kernel": "^5.0",
+        "symfony/yaml": "^5.0"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.15"
+    },
+    "autoload": {
+        "psr-4": {
+            "Contao\\PackageMetaDataIndexer\\": "src/"
+        }
+    }
+}

--- a/indexer/composer.json
+++ b/indexer/composer.json
@@ -18,7 +18,7 @@
         "symfony/yaml": "^5.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.15"
+        "contao/php-cs-fixer": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/indexer/composer.lock
+++ b/indexer/composer.lock
@@ -1,0 +1,2277 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "49670a25ff0935f3e374918ec3ef9e4c",
+    "packages": [
+        {
+            "name": "algolia/algoliasearch-client-php",
+            "version": "1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/algolia/algoliasearch-client-php.git",
+                "reference": "c167ba3247b38b028fc05b1c58e8b5fb5e08d114"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/c167ba3247b38b028fc05b1c58e8b5fb5e08d114",
+                "reference": "c167ba3247b38b028fc05b1c58e8b5fb5e08d114",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-mbstring": "*",
+                "php": "^5.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "satooshi/php-coveralls": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.0": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "AlgoliaSearch": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Algolia Team",
+                    "email": "contact@algolia.com"
+                },
+                {
+                    "name": "Ryan T. Catlin",
+                    "email": "ryan.catlin@gmail.com"
+                },
+                {
+                    "name": "Jonathan H. Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Algolia Search API Client for PHP",
+            "homepage": "https://github.com/algolia/algoliasearch-client-php",
+            "time": "2018-11-06T10:48:00+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2019-11-01T11:05:21+00:00"
+        },
+        {
+            "name": "symfony/cache",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "4572116c640a6bc9fc0047180fe7f9362e5923fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/4572116c640a6bc9fc0047180fe7f9362e5923fc",
+                "reference": "4572116c640a6bc9fc0047180fe7f9362e5923fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "psr/cache": "~1.0",
+                "psr/log": "~1.0",
+                "symfony/cache-contracts": "^1.1.7|^2",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/var-exporter": "^4.4|^5.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "<2.5",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/http-kernel": "<4.4",
+                "symfony/var-dumper": "<4.4"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0",
+                "psr/simple-cache-implementation": "1.0",
+                "symfony/cache-implementation": "1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/cache": "~1.6",
+                "doctrine/dbal": "~2.5",
+                "predis/predis": "~1.1",
+                "psr/simple-cache": "^1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Cache\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Cache component with PSR-6, PSR-16, and tags",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "caching",
+                "psr6"
+            ],
+            "time": "2020-01-31T09:13:47+00:00"
+        },
+        {
+            "name": "symfony/cache-contracts",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache-contracts.git",
+                "reference": "23ed8bfc1a4115feca942cb5f1aacdf3dcdf3c16"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/23ed8bfc1a4115feca942cb5f1aacdf3dcdf3c16",
+                "reference": "23ed8bfc1a4115feca942cb5f1aacdf3dcdf3c16",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "psr/cache": "^1.0"
+            },
+            "suggest": {
+                "symfony/cache-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Cache\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to caching",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-11-18T17:27:11+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "91c294166c38d8c0858a86fad76d8c14dc1144c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/91c294166c38d8c0858a86fad76d8c14dc1144c8",
+                "reference": "91c294166c38d8c0858a86fad76d8c14dc1144c8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/service-contracts": "^1.1|^2"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<4.4",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/event-dispatcher": "^4.4|^5.0",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-01-25T15:56:29+00:00"
+        },
+        {
+            "name": "symfony/error-handler",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/error-handler.git",
+                "reference": "c263709b4570387f3fe339c4f05aae66740cf2ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/c263709b4570387f3fe339c4f05aae66740cf2ab",
+                "reference": "c263709b4570387f3fe339c4f05aae66740cf2ab",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "psr/log": "^1.0",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "require-dev": {
+                "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/serializer": "^4.4|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ErrorHandler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony ErrorHandler Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-01-31T09:13:47+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "4a7a8cdca1120c091b4797f0e5bba69c1e783224"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/4a7a8cdca1120c091b4797f0e5bba69c1e783224",
+                "reference": "4a7a8cdca1120c091b4797f0e5bba69c1e783224",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/event-dispatcher-contracts": "^2"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<4.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/expression-language": "^4.4|^5.0",
+                "symfony/http-foundation": "^4.4|^5.0",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/stopwatch": "^4.4|^5.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-01-10T21:57:37+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "af23c2584d4577d54661c434446fb8fbed6025dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/af23c2584d4577d54661c434446fb8fbed6025dd",
+                "reference": "af23c2584d4577d54661c434446fb8fbed6025dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "psr/event-dispatcher": "^1"
+            },
+            "suggest": {
+                "symfony/event-dispatcher-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-11-18T17:27:11+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "4176e7cb846fe08f32518b7e0ed8462e2db8d9bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/4176e7cb846fe08f32518b7e0ed8462e2db8d9bb",
+                "reference": "4176e7cb846fe08f32518b7e0ed8462e2db8d9bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-01-04T14:08:26+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "4240ae267d89db5b694bdb5712e691b1e24cdc26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/4240ae267d89db5b694bdb5712e691b1e24cdc26",
+                "reference": "4240ae267d89db5b694bdb5712e691b1e24cdc26",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "psr/log": "^1.0",
+                "symfony/http-client-contracts": "^1.1.8|^2",
+                "symfony/polyfill-php73": "^1.11",
+                "symfony/service-contracts": "^1.0|^2"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "1.1"
+            },
+            "require-dev": {
+                "guzzlehttp/promises": "^1.3.1",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "psr/http-client": "^1.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpClient component",
+            "homepage": "https://symfony.com",
+            "time": "2020-01-31T09:13:47+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "378868b61b85c5cac6822d4f84e26999c9f2e881"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/378868b61b85c5cac6822d4f84e26999c9f2e881",
+                "reference": "378868b61b85c5cac6822d4f84e26999c9f2e881",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5"
+            },
+            "suggest": {
+                "symfony/http-client-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-11-26T23:25:11+00:00"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "2832d8cffc3a91df550ac42bcdce602f8c08be3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/2832d8cffc3a91df550ac42bcdce602f8c08be3e",
+                "reference": "2832d8cffc3a91df550ac42bcdce602f8c08be3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/mime": "^4.4|^5.0",
+                "symfony/polyfill-mbstring": "~1.1"
+            },
+            "require-dev": {
+                "predis/predis": "~1.0",
+                "symfony/expression-language": "^4.4|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpFoundation Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-01-31T09:13:47+00:00"
+        },
+        {
+            "name": "symfony/http-kernel",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-kernel.git",
+                "reference": "1f4179489af4ead692fd375b7d9ac675da4215a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/1f4179489af4ead692fd375b7d9ac675da4215a7",
+                "reference": "1f4179489af4ead692fd375b7d9ac675da4215a7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "psr/log": "~1.0",
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/event-dispatcher": "^5.0",
+                "symfony/http-foundation": "^4.4|^5.0",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-php73": "^1.9"
+            },
+            "conflict": {
+                "symfony/browser-kit": "<4.4",
+                "symfony/cache": "<5.0",
+                "symfony/config": "<5.0",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/doctrine-bridge": "<5.0",
+                "symfony/form": "<5.0",
+                "symfony/http-client": "<5.0",
+                "symfony/mailer": "<5.0",
+                "symfony/messenger": "<5.0",
+                "symfony/translation": "<5.0",
+                "symfony/twig-bridge": "<5.0",
+                "symfony/validator": "<5.0",
+                "twig/twig": "<2.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/cache": "~1.0",
+                "symfony/browser-kit": "^4.4|^5.0",
+                "symfony/config": "^5.0",
+                "symfony/console": "^4.4|^5.0",
+                "symfony/css-selector": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/dom-crawler": "^4.4|^5.0",
+                "symfony/expression-language": "^4.4|^5.0",
+                "symfony/finder": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "symfony/routing": "^4.4|^5.0",
+                "symfony/stopwatch": "^4.4|^5.0",
+                "symfony/translation": "^4.4|^5.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "twig/twig": "^2.4|^3.0"
+            },
+            "suggest": {
+                "symfony/browser-kit": "",
+                "symfony/config": "",
+                "symfony/console": "",
+                "symfony/dependency-injection": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpKernel\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpKernel Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-01-31T12:49:38+00:00"
+        },
+        {
+            "name": "symfony/mime",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "2a3c7fee1f1a0961fa9cf360d5da553d05095e59"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/2a3c7fee1f1a0961fa9cf360d5da553d05095e59",
+                "reference": "2a3c7fee1f1a0961fa9cf360d5da553d05095e59",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "symfony/mailer": "<4.4"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10",
+                "symfony/dependency-injection": "^4.4|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A library to manipulate MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "time": "2020-01-04T14:08:26+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.14-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2020-01-13T11:15:53+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "6842f1a39cf7d580655688069a03dd7cd83d244a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/6842f1a39cf7d580655688069a03dd7cd83d244a",
+                "reference": "6842f1a39cf7d580655688069a03dd7cd83d244a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php72": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.14-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2020-01-17T12:01:36+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "34094cfa9abe1f0f14f48f490772db7a775559f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/34094cfa9abe1f0f14f48f490772db7a775559f2",
+                "reference": "34094cfa9abe1f0f14f48f490772db7a775559f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.14-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2020-01-13T11:15:53+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "46ecacf4751dd0dc81e4f6bf01dbf9da1dc1dadf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/46ecacf4751dd0dc81e4f6bf01dbf9da1dc1dadf",
+                "reference": "46ecacf4751dd0dc81e4f6bf01dbf9da1dc1dadf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.14-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2020-01-13T11:15:53+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "5e66a0fa1070bf46bec4bea7962d285108edd675"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/5e66a0fa1070bf46bec4bea7962d285108edd675",
+                "reference": "5e66a0fa1070bf46bec4bea7962d285108edd675",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.14-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2020-01-13T11:15:53+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "144c5e51266b281231e947b51223ba14acf1a749"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/144c5e51266b281231e947b51223ba14acf1a749",
+                "reference": "144c5e51266b281231e947b51223ba14acf1a749",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-11-18T17:27:11+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "923591cfb78a935f0c98968fedfad05bfda9d01f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/923591cfb78a935f0c98968fedfad05bfda9d01f",
+                "reference": "923591cfb78a935f0c98968fedfad05bfda9d01f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.3",
+                "symfony/console": "<4.4"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "symfony/console": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "twig/twig": "^2.4|^3.0"
+            },
+            "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
+                "ext-intl": "To show region name in time zone dump",
+                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
+            },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "time": "2020-01-25T15:56:29+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "960f9ac0fdbd642461ed29d7717aeb2a94d428b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/960f9ac0fdbd642461ed29d7717aeb2a94d428b9",
+                "reference": "960f9ac0fdbd642461ed29d7717aeb2a94d428b9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5"
+            },
+            "require-dev": {
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A blend of var_export() + serialize() to turn any serializable data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "serialize"
+            ],
+            "time": "2020-01-04T14:08:26+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "69b44e3b8f90949aee2eb3aa9b86ceeb01cbf62a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/69b44e3b8f90949aee2eb3aa9b86ceeb01cbf62a",
+                "reference": "69b44e3b8f90949aee2eb3aa9b86ceeb01cbf62a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<4.4"
+            },
+            "require-dev": {
+                "symfony/console": "^4.4|^5.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-01-21T11:12:28+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "composer/semver",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
+                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "time": "2020-01-13T12:06:48+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "cbe23383749496fe0f373345208b79568e4bc248"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/cbe23383749496fe0f373345208b79568e4bc248",
+                "reference": "cbe23383749496fe0f373345208b79568e4bc248",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "time": "2019-11-06T16:40:04+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "904dca4eb10715b92569fbcd79e201d5c349b6bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/904dca4eb10715b92569fbcd79e201d5c349b6bc",
+                "reference": "904dca4eb10715b92569fbcd79e201d5c349b6bc",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^7.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2019-10-01T18:55:10+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "5242d66dbeb21a30dd8a3e66bf7a73b66e05e1f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/5242d66dbeb21a30dd8a3e66bf7a73b66e05e1f6",
+                "reference": "5242d66dbeb21a30dd8a3e66bf7a73b66e05e1f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "time": "2019-10-30T14:39:59+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v2.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "c8afb599858876e95e8ebfcd97812d383fa23f02"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/c8afb599858876e95e8ebfcd97812d383fa23f02",
+                "reference": "c8afb599858876e95e8ebfcd97812d383fa23f02",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^1.4",
+                "composer/xdebug-handler": "^1.2",
+                "doctrine/annotations": "^1.2",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": "^5.6 || ^7.0",
+                "php-cs-fixer/diff": "^1.3",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
+                "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",
+                "symfony/finder": "^3.0 || ^4.0 || ^5.0",
+                "symfony/options-resolver": "^3.0 || ^4.0 || ^5.0",
+                "symfony/polyfill-php70": "^1.0",
+                "symfony/polyfill-php72": "^1.4",
+                "symfony/process": "^3.0 || ^4.0 || ^5.0",
+                "symfony/stopwatch": "^3.0 || ^4.0 || ^5.0"
+            },
+            "require-dev": {
+                "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
+                "justinrainbow/json-schema": "^5.0",
+                "keradus/cli-executor": "^1.2",
+                "mikey179/vfsstream": "^1.6",
+                "php-coveralls/php-coveralls": "^2.1",
+                "php-cs-fixer/accessible-object": "^1.0",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.1",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
+                "phpunitgoodpractices/traits": "^1.8",
+                "symfony/phpunit-bridge": "^4.3 || ^5.0",
+                "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
+            },
+            "suggest": {
+                "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "For IsIdenticalString constraint.",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "For XmlMatchesXsd constraint.",
+                "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "classmap": [
+                    "tests/Test/AbstractFixerTestCase.php",
+                    "tests/Test/AbstractIntegrationCaseFactory.php",
+                    "tests/Test/AbstractIntegrationTestCase.php",
+                    "tests/Test/Assert/AssertTokensTrait.php",
+                    "tests/Test/IntegrationCase.php",
+                    "tests/Test/IntegrationCaseFactory.php",
+                    "tests/Test/IntegrationCaseFactoryInterface.php",
+                    "tests/Test/InternalIntegrationCaseFactory.php",
+                    "tests/TestCase.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "time": "2019-11-25T22:10:32+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.99",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2018-07-02T15:55:56+00:00"
+        },
+        {
+            "name": "php-cs-fixer/diff",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/diff.git",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "symfony/process": "^3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "SpacePossum"
+                }
+            ],
+            "description": "sebastian/diff v2 backport support for PHP5.6",
+            "homepage": "https://github.com/PHP-CS-Fixer",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2018-02-15T16:58:55+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "3afadc0f57cd74f86379d073e694b0f2cda2a88c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3afadc0f57cd74f86379d073e694b0f2cda2a88c",
+                "reference": "3afadc0f57cd74f86379d073e694b0f2cda2a88c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-01-21T08:40:24+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "b1ab86ce52b0c0abe031367a173005a025e30e04"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/b1ab86ce52b0c0abe031367a173005a025e30e04",
+                "reference": "b1ab86ce52b0c0abe031367a173005a025e30e04",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony OptionsResolver Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "time": "2020-01-04T14:08:26+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php70",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php70.git",
+                "reference": "419c4940024c30ccc033650373a1fe13890d3255"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/419c4940024c30ccc033650373a1fe13890d3255",
+                "reference": "419c4940024c30ccc033650373a1fe13890d3255",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "~1.0|~2.0|~9.99",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.14-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php70\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2020-01-13T11:15:53+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "f9ffd870f5ac01abec7b2b5e15f904ca9400ecd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f9ffd870f5ac01abec7b2b5e15f904ca9400ecd1",
+                "reference": "f9ffd870f5ac01abec7b2b5e15f904ca9400ecd1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-01-09T09:53:06+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "5d9add8034135b9a5f7b101d1e42c797e7f053e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/5d9add8034135b9a5f7b101d1e42c797e7f053e4",
+                "reference": "5d9add8034135b9a5f7b101d1e42c797e7f053e4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/service-contracts": "^1.0|^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-01-04T14:08:26+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^7.3",
+        "ext-ctype": "*",
+        "ext-iconv": "*",
+        "ext-json": "*"
+    },
+    "platform-dev": []
+}

--- a/indexer/composer.lock
+++ b/indexer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49670a25ff0935f3e374918ec3ef9e4c",
+    "content-hash": "ef4bc84a10a1433062a79ad958d59941",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -1683,6 +1683,43 @@
                 "performance"
             ],
             "time": "2019-11-06T16:40:04+00:00"
+        },
+        {
+            "name": "contao/php-cs-fixer",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/contao/php-cs-fixer.git",
+                "reference": "2dc174e418d6e98efb7da94dbe25e4c73e91d4bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/contao/php-cs-fixer/zipball/2dc174e418d6e98efb7da94dbe25e4c73e91d4bb",
+                "reference": "2dc174e418d6e98efb7da94dbe25e4c73e91d4bb",
+                "shasum": ""
+            },
+            "require": {
+                "friendsofphp/php-cs-fixer": "^2.14",
+                "php": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Contao\\PhpCsFixer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Leo Feyer",
+                    "homepage": "https://github.com/leofeyer"
+                }
+            ],
+            "description": "PHP-CS-Fixer configurations for Contao",
+            "time": "2019-12-18T13:34:27+00:00"
         },
         {
             "name": "doctrine/annotations",

--- a/indexer/index
+++ b/indexer/index
@@ -1,0 +1,39 @@
+#!/usr/bin/env php
+<?php
+
+require __DIR__.'/vendor/autoload.php';
+
+use AlgoliaSearch\Client;
+use Contao\PackageMetaDataIndexer\Command\IndexCommand;
+use Contao\PackageMetaDataIndexer\MetaDataRepository;
+use Contao\PackageMetaDataIndexer\Package\Factory;
+use Contao\PackageMetaDataIndexer\Packagist;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\HttpClient\CachingHttpClient;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpKernel\HttpCache\Store;
+
+ini_set('display_errors', '1');
+ini_set('display_startup_errors', '1');
+error_reporting(E_ALL);
+
+$output = new ConsoleOutput();
+
+$store = new Store(__DIR__.'/cache/http');
+$httpClient = HttpClient::create();
+$httpClient = new CachingHttpClient($httpClient, $store, ['trace_level' => 'full']);
+
+$packagist = new Packagist($output, $httpClient);
+$metadataRepository = new MetaDataRepository(dirname(__DIR__).'/meta');
+$packageFactory = new Factory($metadataRepository, $packagist);
+$algoliaClient = new Client($_SERVER['ALGOLIA_APP_ID'], $_SERVER['ALGOLIA_API_KEY']);
+$cache = new FilesystemAdapter('', 0, __DIR__.'/cache/packages');
+
+$command = new IndexCommand($packagist, $packageFactory, $algoliaClient, $cache, $metadataRepository);
+
+$application = new Application();
+$application->add($command);
+$application->setDefaultCommand($command->getName(), true);
+$application->run(null, $output);

--- a/indexer/index
+++ b/indexer/index
@@ -23,7 +23,7 @@ $output = new ConsoleOutput();
 
 $store = new Store(__DIR__.'/cache/http');
 $httpClient = HttpClient::create();
-$httpClient = new CachingHttpClient($httpClient, $store, ['trace_level' => 'full']);
+$httpClient = new CachingHttpClient($httpClient, $store, [/*'trace_level' => 'full'*/]);
 
 $packagist = new Packagist($output, $httpClient);
 $metadataRepository = new MetaDataRepository(dirname(__DIR__).'/meta');

--- a/indexer/src/Command/IndexCommand.php
+++ b/indexer/src/Command/IndexCommand.php
@@ -95,7 +95,7 @@ class IndexCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 
@@ -106,7 +106,8 @@ class IndexCommand extends Command
             ->addOption('with-stats', null, InputOption::VALUE_NONE, 'Also update statistics (should run less often / generates more API calls).')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do not index any data. Very useful together with -vvv.')
             ->addOption('no-cache', null, InputOption::VALUE_NONE, 'Do not consider local cache (forces an index update).')
-            ->addOption('clear-index', null, InputOption::VALUE_NONE, 'Clears algolia indexes completely (full re-index).');
+            ->addOption('clear-index', null, InputOption::VALUE_NONE, 'Clears algolia indexes completely (full re-index).')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -157,6 +158,7 @@ class IndexCommand extends Command
             // Check if object still exists in collected packages
             $objectID = $item['objectID'];
             $name = substr($objectID, 0, -3);
+
             if (!isset($this->packages[$name])) {
                 $packagesToDeleteFromIndex[] = $objectID;
             }

--- a/indexer/src/Command/IndexCommand.php
+++ b/indexer/src/Command/IndexCommand.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Contao Package Indexer
+ *
+ * @author     Yanick Witschi <yanick.witschi@terminal42.ch>
+ * @author     Andreas Schempp <andreas.schempp@terminal42.ch>
+ * @license    MIT
+ */
+
+namespace Contao\PackageMetaDataIndexer\Command;
+
+use AlgoliaSearch\Client;
+use AlgoliaSearch\Index;
+use Contao\PackageMetaDataIndexer\MetaDataRepository;
+use Contao\PackageMetaDataIndexer\Package\Factory;
+use Contao\PackageMetaDataIndexer\Package\Package;
+use Contao\PackageMetaDataIndexer\Packagist;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class IndexCommand extends Command
+{
+    /**
+     * Languages for the search index.
+     *
+     * @see https://github.com/contao/contao-manager/blob/master/src/i18n/locales.js
+     */
+    public const LANGUAGES = ['en', 'de', 'br', 'cs', 'es', 'fa', 'fr', 'it', 'ja', 'lv', 'nl', 'pl', 'pt', 'ru', 'sr', 'zh'];
+    private const CACHE_PREFIX = 'package-indexer';
+
+    /**
+     * @var Packagist
+     */
+    private $packagist;
+
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @var Index
+     */
+    private $index;
+
+    /**
+     * @var Package[]
+     */
+    private $packages = [];
+
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cacheItemPool;
+
+    /**
+     * @var Factory
+     */
+    private $packageFactory;
+
+    /**
+     * @var MetaDataRepository
+     */
+    private $metaDataRepository;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var SymfonyStyle
+     */
+    private $io;
+
+    public function __construct(Packagist $packagist, Factory $packageFactory, Client $client, CacheItemPoolInterface $cacheItemPool, MetaDataRepository $metaDataRepository)
+    {
+        $this->packagist = $packagist;
+        $this->client = $client;
+        $this->cacheItemPool = $cacheItemPool;
+        $this->packageFactory = $packageFactory;
+        $this->metaDataRepository = $metaDataRepository;
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('package-index')
+            ->setDescription('Indexes package metadata')
+            ->addArgument('package', InputArgument::OPTIONAL, 'Restrict indexing to a given package name.')
+            ->addOption('with-stats', null, InputOption::VALUE_NONE, 'Also update statistics (should run less often / generates more API calls).')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do not index any data. Very useful together with -vvv.')
+            ->addOption('no-cache', null, InputOption::VALUE_NONE, 'Do not consider local cache (forces an index update).')
+            ->addOption('clear-index', null, InputOption::VALUE_NONE, 'Clears algolia indexes completely (full re-index).');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $package = $input->getArgument('package');
+        $dryRun = (bool) $input->getOption('dry-run');
+        $ignoreCache = (bool) $input->getOption('no-cache');
+        $clearIndex = (bool) $input->getOption('clear-index');
+        $updateStats = (bool) $input->getOption('with-stats');
+
+        $this->io = new SymfonyStyle($input, $output);
+        $this->output = $output;
+        $this->packages = [];
+
+        $this->createIndex($clearIndex);
+
+        if (null !== $package) {
+            $packageNames = [$package];
+        } else {
+            $packageNames = array_unique(array_merge(
+                $this->packagist->getPackageNames('contao-bundle'),
+                $this->packagist->getPackageNames('contao-module'),
+                $this->packagist->getPackageNames('contao-component')
+            ));
+        }
+
+        $this->collectPackages($packageNames);
+
+        if (null === $package) {
+            $this->collectAdditionalPackages();
+        }
+
+        $this->indexPackages($dryRun, $ignoreCache, $updateStats);
+
+        // If the index was not cleared completely, delete old/removed packages
+        if (!$clearIndex && null === $package) {
+            $this->deleteRemovedPackages($dryRun);
+        }
+
+        return 0;
+    }
+
+    private function deleteRemovedPackages(bool $dryRun): void
+    {
+        $packagesToDeleteFromIndex = [];
+
+        foreach ($this->index->browse('', ['attributesToRetrieve' => ['objectID']]) as $item) {
+            // Check if object still exists in collected packages
+            $objectID = $item['objectID'];
+            $name = substr($objectID, 0, -3);
+            if (!isset($this->packages[$name])) {
+                $packagesToDeleteFromIndex[] = $objectID;
+            }
+        }
+
+        if (0 === \count($packagesToDeleteFromIndex)) {
+            return;
+        }
+
+        if (!$dryRun) {
+            $this->index->deleteObjects($packagesToDeleteFromIndex);
+        } else {
+            $this->output->writeln(
+                sprintf('Objects to delete from index: %s', json_encode($packagesToDeleteFromIndex)),
+                OutputInterface::VERBOSITY_DEBUG
+            );
+        }
+    }
+
+    private function collectPackages(array $packageNames): void
+    {
+        foreach ($packageNames as $packageName) {
+            $package = $this->packageFactory->create($packageName);
+
+            if (null === $package || !$package->isSupported()) {
+                $this->output->writeln($packageName.' is not supported.', OutputInterface::VERBOSITY_DEBUG);
+                continue;
+            }
+
+            $this->packages[$packageName] = $package;
+            $this->output->writeln('Added '.$packageName, OutputInterface::VERBOSITY_DEBUG);
+        }
+    }
+
+    private function collectAdditionalPackages(): void
+    {
+        $publicPackages = array_keys($this->packages);
+        $availablePackages = $this->metaDataRepository->getPackageNames();
+
+        $additionalPackages = array_diff($availablePackages, $publicPackages);
+
+        if (0 !== \count($additionalPackages)) {
+            $this->collectPackages($additionalPackages);
+        }
+    }
+
+    private function indexPackages(bool $dryRun, bool $ignoreCache, bool $updateStats): void
+    {
+        if (0 === \count($this->packages)) {
+            return;
+        }
+
+        $packages = [];
+
+        // Ignore the ones that do not need any update
+        foreach ($this->packages as $packageName => $package) {
+            $hash = self::CACHE_PREFIX.'-'.$package->getHash($updateStats);
+
+            $cacheItem = $this->cacheItemPool->getItem($hash);
+
+            if (!$ignoreCache) {
+                if (!$cacheItem->isHit()) {
+                    $hitMsg = 'miss';
+                    $cacheItem->set(true);
+                    $this->cacheItemPool->saveDeferred($cacheItem);
+                    $packages[] = $package;
+                } else {
+                    $hitMsg = 'hit';
+                }
+            } else {
+                $packages[] = $package;
+                $hitMsg = 'ignored';
+            }
+
+            $this->output->writeln(
+                sprintf('Cache entry for package "%s" was %s (hash: %s)', $packageName, $hitMsg, $hash),
+                OutputInterface::VERBOSITY_DEBUG
+            );
+        }
+
+        foreach (array_chunk($packages, 100) as $chunk) {
+            $objects = [];
+
+            /** @var Package $package */
+            foreach ($chunk as $package) {
+                $languageKeys = array_unique(array_merge(['en'], array_keys($package->getMeta())));
+
+                foreach ($languageKeys as $language) {
+                    $languages = [$language];
+
+                    if ('en' === $language) {
+                        $languages = array_merge(['en'], array_diff(self::LANGUAGES, $languageKeys));
+                    }
+
+                    $objects[] = $package->getForAlgolia($languages);
+                }
+            }
+
+            if (!$dryRun) {
+                $this->index->saveObjects($objects);
+            } else {
+                $this->output->writeln(
+                    sprintf('Objects to index: %s', json_encode($objects)),
+                    OutputInterface::VERBOSITY_DEBUG
+                );
+            }
+        }
+
+        $this->output->writeln(sprintf('Updated "%s" package(s).', \count($packages)), OutputInterface::VERBOSITY_DEBUG);
+
+        $this->cacheItemPool->commit();
+    }
+
+    private function createIndex(bool $clearIndex): void
+    {
+        if (null !== $this->index) {
+            return;
+        }
+
+        $this->index = $this->client->initIndex($_SERVER['ALGOLIA_INDEX']);
+
+        if ($clearIndex) {
+            $this->index->clearIndex();
+        }
+    }
+}

--- a/indexer/src/MetaDataRepository.php
+++ b/indexer/src/MetaDataRepository.php
@@ -67,7 +67,7 @@ class MetaDataRepository
 
     public function getLogoForPackage(Package $package): ?string
     {
-        list($vendor, $name) = explode('/', $package->getName(), 2);
+        [$vendor, $name] = explode('/', $package->getName(), 2);
         $image = sprintf('%s/%s/logo.svg', $vendor, $name);
 
         if (!$this->fs->exists($this->getMetaDataDir().'/'.$image)) {

--- a/indexer/src/MetaDataRepository.php
+++ b/indexer/src/MetaDataRepository.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Contao Package Indexer
+ *
+ * @author     Yanick Witschi <yanick.witschi@terminal42.ch>
+ * @author     Andreas Schempp <andreas.schempp@terminal42.ch>
+ * @license    MIT
+ */
+
+namespace Contao\PackageMetaDataIndexer;
+
+use Contao\PackageMetaDataIndexer\Package\Package;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+class MetaDataRepository
+{
+    /**
+     * @var string
+     */
+    private $metaDataDir;
+
+    /**
+     * @var Filesystem
+     */
+    private $fs;
+
+    /**
+     * @var array
+     */
+    private $names;
+
+    /**
+     * Metadata constructor.
+     */
+    public function __construct(string $metaDataDir)
+    {
+        $this->metaDataDir = $metaDataDir;
+        $this->fs = new Filesystem();
+    }
+
+    public function getMetaDataDir(): string
+    {
+        return $this->metaDataDir;
+    }
+
+    public function getPackageNames(): array
+    {
+        if (null === $this->names) {
+            $this->names = [];
+
+            $finder = new Finder();
+            $finder->directories()->in($this->getMetaDataDir())->depth('== 1');
+
+            foreach ($finder as $dir) {
+                $this->names[] = basename($dir->getPath()).'/'.$dir->getBasename();
+            }
+        }
+
+        return $this->names;
+    }
+
+    public function getLogoForPackage(Package $package): ?string
+    {
+        list($vendor, $name) = explode('/', $package->getName(), 2);
+        $image = sprintf('%s/%s/logo.svg', $vendor, $name);
+
+        if (!$this->fs->exists($this->getMetaDataDir().'/'.$image)) {
+            $image = sprintf('%s/logo.svg', $vendor);
+
+            if (!$this->fs->exists($this->getMetaDataDir().'/'.$image)) {
+                return null;
+            }
+        }
+
+        // if bigger than 5kb use raw url
+        if (@filesize($this->getMetaDataDir().'/'.$image) > (5 * 1024)) {
+            $logo = sprintf(
+                'https://contao.github.io/package-metadata/meta/'.$image,
+                $package->getName()
+            );
+        } else {
+            $logo = sprintf(
+                'data:image/svg+xml;base64,%s',
+                base64_encode(file_get_contents($this->getMetaDataDir().'/'.$image))
+            );
+        }
+
+        return $logo;
+    }
+
+    public function getComposerJsonForPackage(Package $package): ?array
+    {
+        $file = $this->getMetaDataDir().'/'.$package->getName().'/composer.json';
+
+        if (!$this->fs->exists($file)) {
+            return null;
+        }
+
+        $data = @json_decode(file_get_contents($file), true);
+
+        if (!\is_array($data)) {
+            return null;
+        }
+
+        return $data;
+    }
+
+    public function getMetaDataForPackage(Package $package, string $language): ?array
+    {
+        $file = $this->getMetaDataDir().'/'.$package->getName().'/'.$language.'.yml';
+
+        try {
+            $data = Yaml::parseFile($file);
+            $data = (\array_key_exists($language, $data) && \is_array($data[$language])) ? $data[$language] : [];
+
+            $data = $this->filterMetadata($data);
+            $data['metadata'] = sprintf(
+                'https://github.com/contao/package-metadata/blob/master/meta/%s/%s.yml',
+                $package->getName(),
+                $language
+            );
+        } catch (ParseException $e) {
+            return null;
+        }
+
+        return $data;
+    }
+
+    private function filterMetadata(array $data): array
+    {
+        return array_intersect_key(
+            $data,
+            array_flip(['title', 'description', 'keywords', 'homepage', 'support', 'suggest', 'dependency'])
+        );
+    }
+}

--- a/indexer/src/Package/Factory.php
+++ b/indexer/src/Package/Factory.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Contao Package Indexer
+ *
+ * @author     Yanick Witschi <yanick.witschi@terminal42.ch>
+ * @author     Andreas Schempp <andreas.schempp@terminal42.ch>
+ * @license    MIT
+ */
+
+namespace Contao\PackageMetaDataIndexer\Package;
+
+use Contao\PackageMetaDataIndexer\Command\IndexCommand;
+use Contao\PackageMetaDataIndexer\MetaDataRepository;
+use Contao\PackageMetaDataIndexer\Packagist;
+
+class Factory
+{
+    /**
+     * @var MetaDataRepository
+     */
+    private $metaData;
+
+    /**
+     * @var Packagist
+     */
+    private $packagist;
+
+    /**
+     * @var array
+     */
+    private $cache = [];
+
+    public function __construct(MetaDataRepository $metaData, Packagist $packagist)
+    {
+        $this->metaData = $metaData;
+        $this->packagist = $packagist;
+    }
+
+    public function create(string $name): Package
+    {
+        $cacheKey = 'basic-'.$name;
+        if (isset($this->cache[$cacheKey])) {
+            return $this->cache[$cacheKey];
+        }
+
+        $package = new Package($name);
+        $data = $this->packagist->getPackageData($name);
+
+        if (null === $data) {
+            $this->setDataForPrivate($package);
+        } else {
+            $this->setBasicDataFromPackagist($data, $package);
+        }
+
+        $package->setLogo($this->metaData->getLogoForPackage($package));
+        $this->addMeta($package);
+
+        if (!$package->isSupported()) {
+            if (!empty($package->getMeta())) {
+                $package->setSupported(true);
+            } elseif (null !== $package->getLogo()) {
+                $package->setSupported(true);
+                $package->setDependency(true);
+            }
+        }
+
+        return $this->cache[$cacheKey] = $package;
+    }
+
+    private function setDataForPrivate(Package $package): void
+    {
+        $package->setSupported(true);
+        $package->setPrivate(true);
+
+        $data = $this->metaData->getComposerJsonForPackage($package);
+
+        if (null === $data) {
+            return;
+        }
+
+        $package->setDescription($data['description'] ?? null);
+        $package->setKeywords($data['keywords'] ?? null);
+        $package->setHomepage($data['homepage'] ?? null);
+        $package->setSupport($data['support'] ?? null);
+        $package->setVersions(isset($data['version']) ? [$data['version']] : []);
+        $package->setLicense(isset($data['license']) ? (array) $data['license'] : null);
+        $package->setReleased($data['time'] ?? null);
+        $package->setUpdated($data['time'] ?? null);
+        $package->setSuggest($data['suggest'] ?? null);
+    }
+
+    private function setBasicDataFromPackagist(array $data, Package $package): void
+    {
+        $latest = $this->findLatestVersion($data['p']);
+        $versions = array_keys($data['packages']['versions']);
+        // $data['p'] contains the non-cached data, while only $data['packages'] has the "support" metadata
+        $latestPackages = $this->findLatestVersion($data['packages']['versions']);
+
+        sort($versions);
+
+        $package->setTitle($package->getName());
+        $package->setDescription($latest['description'] ?? null);
+        $package->setKeywords($latest['keywords'] ?? null);
+        $package->setHomepage($latest['homepage'] ?? null);
+        $package->setSupport($latestPackages['support'] ?? null);
+        $package->setVersions($versions);
+        $package->setLicense($latest['license'] ?? null);
+        $package->setDownloads((int) ($data['packages']['downloads']['total'] ?? 0));
+        $package->setFavers((int) ($data['packages']['favers'] ?? 0));
+        $package->setReleased($data['packages']['time'] ?? null);
+        $package->setUpdated($latest['time'] ?? null);
+        $package->setSupported($this->isSupported($data['packages']['versions']));
+        $package->setAbandoned($data['packages']['abandoned'] ?? false);
+        $package->setSuggest($latest['suggest'] ?? null);
+        $package->setPrivate(false);
+    }
+
+    private function isSupported(array $versionsData): bool
+    {
+        foreach ($versionsData as $version => $versionData) {
+            if (0 === strpos((string) $version, 'dev-')) {
+                continue;
+            }
+
+            if ('contao-component' === $versionData['type']) {
+                return true;
+            }
+
+            if (!isset($versionData['require']['contao/core-bundle'])) {
+                continue;
+            }
+
+            if ('contao-bundle' !== $versionData['type'] || isset($versionData['extra']['contao-manager-plugin'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function addMeta(Package $package): void
+    {
+        $meta = [];
+
+        foreach (IndexCommand::LANGUAGES as $language) {
+            if (null !== ($data = $this->metaData->getMetaDataForPackage($package, $language))) {
+                $meta[$language] = $data;
+            }
+        }
+
+        $package->setMeta($meta);
+    }
+
+    private function findLatestVersion(array $versions)
+    {
+        $latest = array_reduce(
+            array_keys($versions),
+            static function (?string $prev, string $curr) use ($versions) {
+                if (null === $prev) {
+                    return $curr;
+                }
+
+                if ('-dev' !== substr($prev, -4)
+                    && 0 !== strpos($prev, 'dev-')
+                    && (0 === strpos($curr, 'dev-') || '-dev' === substr($curr, -4))
+                ) {
+                    return $prev;
+                }
+
+                if ('-dev' !== substr($curr, -4)
+                    && 0 !== strpos($curr, 'dev-')
+                    && (0 === strpos($prev, 'dev-') || '-dev' === substr($prev, -4))
+                ) {
+                    return $curr;
+                }
+
+                return strtotime($versions[$prev]['time']) > strtotime($versions[$curr]['time']) ? $prev : $curr;
+            }
+        );
+
+        return $versions[$latest];
+    }
+}

--- a/indexer/src/Package/Factory.php
+++ b/indexer/src/Package/Factory.php
@@ -42,6 +42,7 @@ class Factory
     public function create(string $name): Package
     {
         $cacheKey = 'basic-'.$name;
+
         if (isset($this->cache[$cacheKey])) {
             return $this->cache[$cacheKey];
         }

--- a/indexer/src/Package/Package.php
+++ b/indexer/src/Package/Package.php
@@ -1,0 +1,409 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Contao Package Indexer
+ *
+ * @author     Yanick Witschi <yanick.witschi@terminal42.ch>
+ * @author     Andreas Schempp <andreas.schempp@terminal42.ch>
+ * @license    MIT
+ */
+
+namespace Contao\PackageMetaDataIndexer\Package;
+
+class Package
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $title;
+
+    /**
+     * @var string
+     */
+    private $description;
+
+    /**
+     * @var array
+     */
+    private $keywords;
+
+    /**
+     * @var string
+     */
+    private $homepage;
+
+    /**
+     * @var array
+     */
+    private $support;
+
+    /**
+     * @var array
+     */
+    private $versions = [];
+
+    /**
+     * @var array
+     */
+    private $license;
+
+    /**
+     * @var int
+     */
+    private $downloads = 0;
+
+    /**
+     * @var int
+     */
+    private $favers = 0;
+
+    /**
+     * @var string
+     */
+    private $released;
+
+    /**
+     * @var string
+     */
+    private $updated;
+
+    /**
+     * @var bool
+     */
+    private $supported = false;
+
+    /**
+     * @var bool
+     */
+    private $dependency = false;
+
+    /**
+     * @var string|bool
+     */
+    private $abandoned = false;
+
+    /**
+     * @var bool
+     */
+    private $private = false;
+
+    /**
+     * @var array|null
+     */
+    private $suggest;
+
+    /**
+     * @var string
+     */
+    private $logo;
+
+    /**
+     * @var array
+     */
+    private $meta = [];
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title ?: $this->name;
+    }
+
+    public function setTitle(?string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getKeywords(): ?array
+    {
+        return $this->keywords;
+    }
+
+    public function setKeywords(?array $keywords): self
+    {
+        $this->keywords = $keywords;
+
+        return $this;
+    }
+
+    public function getHomepage(): ?string
+    {
+        return $this->homepage;
+    }
+
+    public function setHomepage(?string $homepage): self
+    {
+        $this->homepage = $homepage;
+
+        return $this;
+    }
+
+    public function getSupport(): ?array
+    {
+        return $this->support;
+    }
+
+    public function setSupport(?array $support): self
+    {
+        $this->support = $support;
+
+        return $this;
+    }
+
+    public function getVersions(): array
+    {
+        return $this->versions;
+    }
+
+    public function setVersions(array $versions): self
+    {
+        $this->versions = $versions;
+
+        return $this;
+    }
+
+    public function getLicense(): ?array
+    {
+        return $this->license;
+    }
+
+    public function setLicense(?array $license): self
+    {
+        $this->license = $license;
+
+        return $this;
+    }
+
+    public function getDownloads(): int
+    {
+        return $this->downloads;
+    }
+
+    public function setDownloads(int $downloads): self
+    {
+        $this->downloads = $downloads;
+
+        return $this;
+    }
+
+    public function getFavers(): int
+    {
+        return $this->favers;
+    }
+
+    public function setFavers(int $favers): self
+    {
+        $this->favers = $favers;
+
+        return $this;
+    }
+
+    public function getReleased(): ?string
+    {
+        return $this->released;
+    }
+
+    public function setReleased(?string $released): self
+    {
+        $this->released = $released;
+
+        return $this;
+    }
+
+    public function getUpdated(): ?string
+    {
+        return $this->updated;
+    }
+
+    public function setUpdated(?string $updated): self
+    {
+        $this->updated = $updated;
+
+        return $this;
+    }
+
+    public function isSupported(): bool
+    {
+        return $this->supported;
+    }
+
+    public function setSupported(bool $supported): self
+    {
+        $this->supported = $supported;
+
+        return $this;
+    }
+
+    public function isDependency(): bool
+    {
+        return $this->dependency;
+    }
+
+    public function setDependency(bool $dependency): self
+    {
+        $this->dependency = $dependency;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|string
+     */
+    public function getAbandoned()
+    {
+        return $this->abandoned;
+    }
+
+    public function setAbandoned($abandoned): self
+    {
+        $this->abandoned = $abandoned;
+
+        return $this;
+    }
+
+    public function isPrivate(): bool
+    {
+        return $this->private;
+    }
+
+    public function setPrivate(bool $private): self
+    {
+        $this->private = $private;
+
+        return $this;
+    }
+
+    public function getSuggest(): ?array
+    {
+        return $this->suggest;
+    }
+
+    public function setSuggest(?array $suggest): self
+    {
+        $this->suggest = $suggest;
+
+        return $this;
+    }
+
+    public function getLogo(): ?string
+    {
+        return $this->logo;
+    }
+
+    public function setLogo(?string $logo): self
+    {
+        $this->logo = $logo;
+
+        return $this;
+    }
+
+    public function getMeta(): array
+    {
+        return $this->meta;
+    }
+
+    public function getMetaForLanguage(string $language): array
+    {
+        $meta = $this->getMeta();
+
+        if (isset($meta[$language])) {
+            return (array) $meta[$language];
+        }
+
+        return [];
+    }
+
+    public function setMeta(array $meta): self
+    {
+        $this->meta = $meta;
+
+        return $this;
+    }
+
+    public function getForAlgolia(array $languages): array
+    {
+        $language = reset($languages);
+
+        $data = [
+            'objectID' => $this->getName().'/'.$language,
+            'name' => $this->getName(),
+            'title' => $this->getTitle(),
+            'description' => $this->getDescription(),
+            'keywords' => $this->getKeywords(),
+            'homepage' => $this->getHomepage(),
+            'support' => $this->getSupport(),
+            'license' => $this->getLicense(),
+            'downloads' => $this->getDownloads(),
+            'favers' => $this->getFavers(),
+            'released' => $this->getReleased(),
+            'updated' => $this->getUpdated(),
+            'dependency' => $this->isDependency(),
+            'abandoned' => $this->getAbandoned(),
+            'private' => $this->isPrivate(),
+            'suggest' => $this->getSuggest(),
+            'logo' => $this->getLogo(),
+            'languages' => $languages,
+        ];
+
+        $data = array_replace_recursive($data, $this->getMetaForLanguage($language));
+
+        return array_filter($data, function ($v) {
+            return null !== $v;
+        });
+    }
+
+    public function getHash(bool $includeStatistics = false): string
+    {
+        $info = [
+            $this->getName(),
+            $this->getDescription(),
+            $this->getKeywords(),
+            $this->getHomepage(),
+            $this->getSupport(),
+            $this->getVersions(),
+            $this->getLicense(),
+            $this->isSupported(),
+            $this->isDependency(),
+            $this->getAbandoned(),
+            $this->isPrivate(),
+            $this->getLogo(),
+            $this->getMeta(),
+        ];
+
+        if ($includeStatistics) {
+            $info[] = $this->getFavers();
+            $info[] = $this->getDownloads();
+        }
+
+        return sha1(json_encode($info));
+    }
+}

--- a/indexer/src/Package/Package.php
+++ b/indexer/src/Package/Package.php
@@ -376,7 +376,7 @@ class Package
 
         $data = array_replace_recursive($data, $this->getMetaForLanguage($language));
 
-        return array_filter($data, function ($v) {
+        return array_filter($data, static function ($v) {
             return null !== $v;
         });
     }

--- a/indexer/src/Packagist.php
+++ b/indexer/src/Packagist.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class Packagist
 {
-    const PLATFORM_PACKAGE_REGEX = '{^(?:php(?:-64bit|-ipv6|-zts|-debug)?|hhvm|(?:ext|lib)-[^/ ]+)$}i';
+    private const PLATFORM_PACKAGE_REGEX = '{^(?:php(?:-64bit|-ipv6|-zts|-debug)?|hhvm|(?:ext|lib)-[^/ ]+)$}i';
 
     /**
      * Blacklisted packages that should not be found.

--- a/indexer/src/Packagist.php
+++ b/indexer/src/Packagist.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Contao Package Indexer
+ *
+ * @author     Yanick Witschi <yanick.witschi@terminal42.ch>
+ * @author     Andreas Schempp <andreas.schempp@terminal42.ch>
+ * @license    MIT
+ */
+
+namespace Contao\PackageMetaDataIndexer;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class Packagist
+{
+    const PLATFORM_PACKAGE_REGEX = '{^(?:php(?:-64bit|-ipv6|-zts|-debug)?|hhvm|(?:ext|lib)-[^/ ]+)$}i';
+
+    /**
+     * Blacklisted packages that should not be found.
+     */
+    private const BLACKLIST = ['contao/installation-bundle', 'contao/module-devtools', 'contao/module-repository', 'contao/contao'];
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var HttpClientInterface
+     */
+    private $client;
+
+    public function __construct(OutputInterface $output, HttpClientInterface $client)
+    {
+        $this->output = $output;
+        $this->client = $client;
+    }
+
+    public function getPackageNames(string $type): array
+    {
+        try {
+            $data = $this->getJson('https://packagist.org/packages/list.json?type='.$type);
+        } catch (ExceptionInterface $e) {
+            $this->output->writeln(sprintf('Error fetching package names of type "%s"', $type));
+
+            return [];
+        }
+
+        return array_diff($data['packageNames'], self::BLACKLIST);
+    }
+
+    public function getPackageData(string $name): ?array
+    {
+        if (preg_match(self::PLATFORM_PACKAGE_REGEX, $name)) {
+            return null;
+        }
+
+        try {
+            $packagesData = $this->getJson('https://packagist.org/packages/'.$name.'.json');
+
+            if (!isset($packagesData['package'])) {
+                return null;
+            }
+
+            $repoData = $this->getJson('https://repo.packagist.org/p/'.$name.'.json');
+
+            if (!isset($repoData['packages'][$name])) {
+                return null;
+            }
+
+            $data['packages'] = $packagesData['package'];
+            $data['p'] = $repoData['packages'][$name];
+        } catch (ExceptionInterface $e) {
+            $this->output->writeln(sprintf('Error fetching package "%s"', $name), OutputInterface::VERBOSITY_DEBUG);
+
+            return null;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @throws ExceptionInterface
+     */
+    private function getJson(string $uri): array
+    {
+        $response = $this->client->request('GET', $uri);
+        $headers = $response->getHeaders();
+
+        if (isset($headers['x-symfony-cache'])) {
+            $this->output->writeln($headers['x-symfony-cache'], OutputInterface::VERBOSITY_DEBUG);
+        }
+
+        return $response->toArray();
+    }
+}

--- a/linter/composer.json
+++ b/linter/composer.json
@@ -2,6 +2,7 @@
     "name": "contao/package-metadata-linter",
     "description": "A linter for the package meta data",
     "type": "project",
+    "license": "MIT",
     "require": {
         "php": "^7.4",
         "ext-json": "*",
@@ -16,7 +17,6 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16"
     },
-    "license": "MIT",
     "authors": [
         {
             "name": "Yanick Witschi",


### PR DESCRIPTION
This merges [contao/package-indexer](https://github.com/contao/package-indexer) into the metadata repository. Similar to the linter, this tool _belongs_ to the metadata.

I have also Removed `symfony/flex` and rewritten everything to `symfony/http-client` instead of Guzzle. We can now use GitHub Actions to update the index every 30 minutes, which provides the advantage of "visible" updates. Now people can see when the update has run and no longer on our terminal42 server.

Some ideas for further updates (not for this PR):
 1. Show which packages have been updated, so one can see in the GitHub Actions what has been indexed.
 2. Automatically update the index on a merge in master. This should only index a specific package, the CLI already has that option, but we need to build a CI action that finds out what packages have changes _since last commit_ …