### PR TITLE
Correctly cache algolia updates on GitHub actions

### DIFF
--- a/.github/workflows/index-scheduled.yaml
+++ b/.github/workflows/index-scheduled.yaml
@@ -1,13 +1,8 @@
-name: Update Package Metadata Index
+name: Update package index every 30 minutes
 
-#on:
-#    push:
-#        branches:
-#            - master
-#        paths:
-#            - 'meta/*'
-#    schedule:
-#        - cron: '*/30 * * * *'
+on:
+    schedule:
+        - cron: '*/30 * * * *'
 
 jobs:
     index:
@@ -23,16 +18,19 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v2
 
-            - uses: actions/cache@v1
+            - name: Cache Composer Vendor
+              uses: actions/cache@v1
               with:
                   path: indexer/vendor/
-                  key: ${{ runner.os }}-composer-vendor
+                  key: ${{ runner.os }}-indexer-vendor-${{ hashFiles('indexer/composer.lock') }}
+                  restore-keys: ${{ runner.os }}-indexer-vendor-
 
-            - uses: actions/cache@v1
-              id: cache-files
+            - name: Cache Packages
+              uses: actions/cache@v1
               with:
-                  path: indexer/cache/
-                  key: ${{ runner.os }}-cache-files
+                  path: indexer/cache
+                  key: ${{ runner.os }}-indexer-cache-${{ github.sha }}
+                  restore-keys: ${{ runner.os }}-indexer-cache-
 
             - name: Install the dependencies
               run: cd indexer && composer install --no-interaction --no-suggest
@@ -43,7 +41,7 @@ jobs:
                   echo "::set-env name=with_stats::$(expr ${{ github.run_number }} % 24)"
 
             - name: Update Index
-              run: indexer/index ${{ env.with_stats == 0 && '--with-stats' || '' }}
+              run: indexer/index -v ${{ env.with_stats == 0 && '--with-stats' || '' }}
               env:
                   ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
                   ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}

--- a/indexer/composer.json
+++ b/indexer/composer.json
@@ -8,7 +8,6 @@
         "php": "^7.3",
         "ext-json": "*",
         "algolia/algoliasearch-client-php": "^1.27",
-        "symfony/cache": "^5.0",
         "symfony/console": "^5.0",
         "symfony/finder": "^5.0",
         "symfony/http-client": "^5.0",

--- a/indexer/composer.lock
+++ b/indexer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef4bc84a10a1433062a79ad958d59941",
+    "content-hash": "528202d079bcbaa2e1fe70a328b1ec80",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -61,52 +61,6 @@
             "description": "Algolia Search API Client for PHP",
             "homepage": "https://github.com/algolia/algoliasearch-client-php",
             "time": "2018-11-06T10:48:00+00:00"
-        },
-        {
-            "name": "psr/cache",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "time": "2016-08-06T20:24:11+00:00"
         },
         {
             "name": "psr/container",
@@ -249,143 +203,6 @@
                 "psr-3"
             ],
             "time": "2019-11-01T11:05:21+00:00"
-        },
-        {
-            "name": "symfony/cache",
-            "version": "v5.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/cache.git",
-                "reference": "4572116c640a6bc9fc0047180fe7f9362e5923fc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/4572116c640a6bc9fc0047180fe7f9362e5923fc",
-                "reference": "4572116c640a6bc9fc0047180fe7f9362e5923fc",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5",
-                "psr/cache": "~1.0",
-                "psr/log": "~1.0",
-                "symfony/cache-contracts": "^1.1.7|^2",
-                "symfony/service-contracts": "^1.1|^2",
-                "symfony/var-exporter": "^4.4|^5.0"
-            },
-            "conflict": {
-                "doctrine/dbal": "<2.5",
-                "symfony/dependency-injection": "<4.4",
-                "symfony/http-kernel": "<4.4",
-                "symfony/var-dumper": "<4.4"
-            },
-            "provide": {
-                "psr/cache-implementation": "1.0",
-                "psr/simple-cache-implementation": "1.0",
-                "symfony/cache-implementation": "1.0"
-            },
-            "require-dev": {
-                "cache/integration-tests": "dev-master",
-                "doctrine/cache": "~1.6",
-                "doctrine/dbal": "~2.5",
-                "predis/predis": "~1.1",
-                "psr/simple-cache": "^1.0",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/var-dumper": "^4.4|^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Cache\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Cache component with PSR-6, PSR-16, and tags",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "caching",
-                "psr6"
-            ],
-            "time": "2020-01-31T09:13:47+00:00"
-        },
-        {
-            "name": "symfony/cache-contracts",
-            "version": "v2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/cache-contracts.git",
-                "reference": "23ed8bfc1a4115feca942cb5f1aacdf3dcdf3c16"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/23ed8bfc1a4115feca942cb5f1aacdf3dcdf3c16",
-                "reference": "23ed8bfc1a4115feca942cb5f1aacdf3dcdf3c16",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5",
-                "psr/cache": "^1.0"
-            },
-            "suggest": {
-                "symfony/cache-implementation": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Cache\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to caching",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "time": "2019-11-18T17:27:11+00:00"
         },
         {
             "name": "symfony/console",
@@ -1459,66 +1276,6 @@
             "time": "2020-01-25T15:56:29+00:00"
         },
         {
-            "name": "symfony/var-exporter",
-            "version": "v5.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "960f9ac0fdbd642461ed29d7717aeb2a94d428b9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/960f9ac0fdbd642461ed29d7717aeb2a94d428b9",
-                "reference": "960f9ac0fdbd642461ed29d7717aeb2a94d428b9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5"
-            },
-            "require-dev": {
-                "symfony/var-dumper": "^4.4|^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\VarExporter\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A blend of var_export() + serialize() to turn any serializable data structure to plain PHP code",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "clone",
-                "construct",
-                "export",
-                "hydrate",
-                "instantiate",
-                "serialize"
-            ],
-            "time": "2020-01-04T14:08:26+00:00"
-        },
-        {
             "name": "symfony/yaml",
             "version": "v5.0.4",
             "source": {
@@ -2306,8 +2063,6 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.3",
-        "ext-ctype": "*",
-        "ext-iconv": "*",
         "ext-json": "*"
     },
     "platform-dev": []

--- a/indexer/index
+++ b/indexer/index
@@ -8,7 +8,6 @@ use Contao\PackageMetaDataIndexer\Command\IndexCommand;
 use Contao\PackageMetaDataIndexer\MetaDataRepository;
 use Contao\PackageMetaDataIndexer\Package\Factory;
 use Contao\PackageMetaDataIndexer\Packagist;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\HttpClient\CachingHttpClient;
@@ -29,9 +28,7 @@ $packagist = new Packagist($output, $httpClient);
 $metadataRepository = new MetaDataRepository(dirname(__DIR__).'/meta');
 $packageFactory = new Factory($metadataRepository, $packagist);
 $algoliaClient = new Client($_SERVER['ALGOLIA_APP_ID'], $_SERVER['ALGOLIA_API_KEY']);
-$cache = new FilesystemAdapter('', 0, __DIR__.'/cache/packages');
-
-$command = new IndexCommand($packagist, $packageFactory, $algoliaClient, $cache, $metadataRepository);
+$command = new IndexCommand($packagist, $packageFactory, $algoliaClient, $metadataRepository, __DIR__.'/cache/packages.php');
 
 $application = new Application();
 $application->add($command);

--- a/indexer/src/Command/IndexCommand.php
+++ b/indexer/src/Command/IndexCommand.php
@@ -132,8 +132,9 @@ class IndexCommand extends Command
         }
 
         $cache = [];
+
         if (!$ignoreCache && file_exists($this->cacheFile)) {
-            $cache = require($this->cacheFile);
+            $cache = require $this->cacheFile;
 
             if (!\is_array($cache)) {
                 $cache = [];
@@ -158,7 +159,7 @@ class IndexCommand extends Command
     {
         $packagesToDeleteFromIndex = [];
 
-        /** @noinspection PhpUndefinedMethodInspection */
+        /* @noinspection PhpUndefinedMethodInspection */
         foreach ($this->index->browse('', ['attributesToRetrieve' => ['objectID']]) as $item) {
             // Check if object still exists in collected packages
             $objectID = $item['objectID'];
@@ -168,7 +169,6 @@ class IndexCommand extends Command
                 $packagesToDeleteFromIndex[] = $objectID;
             }
         }
-
 
         $total = \count($packagesToDeleteFromIndex);
 
@@ -279,11 +279,11 @@ class IndexCommand extends Command
             return;
         }
 
-        /** @noinspection PhpUnhandledExceptionInspection */
+        /* @noinspection PhpUnhandledExceptionInspection */
         $this->index = $this->client->initIndex($_SERVER['ALGOLIA_INDEX']);
 
         if ($clearIndex) {
-            /** @noinspection PhpUnhandledExceptionInspection */
+            /* @noinspection PhpUnhandledExceptionInspection */
             $this->index->clearIndex();
         }
     }

--- a/indexer/src/Command/IndexCommand.php
+++ b/indexer/src/Command/IndexCommand.php
@@ -18,13 +18,11 @@ use Contao\PackageMetaDataIndexer\MetaDataRepository;
 use Contao\PackageMetaDataIndexer\Package\Factory;
 use Contao\PackageMetaDataIndexer\Package\Package;
 use Contao\PackageMetaDataIndexer\Packagist;
-use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 class IndexCommand extends Command
 {
@@ -34,7 +32,6 @@ class IndexCommand extends Command
      * @see https://github.com/contao/contao-manager/blob/master/src/i18n/locales.js
      */
     public const LANGUAGES = ['en', 'de', 'br', 'cs', 'es', 'fa', 'fr', 'it', 'ja', 'lv', 'nl', 'pl', 'pt', 'ru', 'sr', 'zh'];
-    private const CACHE_PREFIX = 'package-indexer';
 
     /**
      * @var Packagist
@@ -57,11 +54,6 @@ class IndexCommand extends Command
     private $packages = [];
 
     /**
-     * @var CacheItemPoolInterface
-     */
-    private $cacheItemPool;
-
-    /**
      * @var Factory
      */
     private $packageFactory;
@@ -72,22 +64,22 @@ class IndexCommand extends Command
     private $metaDataRepository;
 
     /**
+     * @var string
+     */
+    private $cacheFile;
+
+    /**
      * @var OutputInterface
      */
     private $output;
 
-    /**
-     * @var SymfonyStyle
-     */
-    private $io;
-
-    public function __construct(Packagist $packagist, Factory $packageFactory, Client $client, CacheItemPoolInterface $cacheItemPool, MetaDataRepository $metaDataRepository)
+    public function __construct(Packagist $packagist, Factory $packageFactory, Client $client, MetaDataRepository $metaDataRepository, string $cacheFile)
     {
         $this->packagist = $packagist;
         $this->client = $client;
-        $this->cacheItemPool = $cacheItemPool;
         $this->packageFactory = $packageFactory;
         $this->metaDataRepository = $metaDataRepository;
+        $this->cacheFile = $cacheFile;
 
         parent::__construct();
     }
@@ -118,7 +110,6 @@ class IndexCommand extends Command
         $clearIndex = (bool) $input->getOption('clear-index');
         $updateStats = (bool) $input->getOption('with-stats');
 
-        $this->io = new SymfonyStyle($input, $output);
         $this->output = $output;
         $this->packages = [];
 
@@ -140,11 +131,24 @@ class IndexCommand extends Command
             $this->collectAdditionalPackages();
         }
 
-        $this->indexPackages($dryRun, $ignoreCache, $updateStats);
+        $cache = [];
+        if (!$ignoreCache && file_exists($this->cacheFile)) {
+            $cache = require($this->cacheFile);
+
+            if (!\is_array($cache)) {
+                $cache = [];
+            }
+        }
+
+        $this->indexPackages($dryRun, $cache, $updateStats);
 
         // If the index was not cleared completely, delete old/removed packages
         if (!$clearIndex && null === $package) {
             $this->deleteRemovedPackages($dryRun);
+        }
+
+        if (!$ignoreCache) {
+            file_put_contents($this->cacheFile, '<?php return '.var_export($cache, true).';');
         }
 
         return 0;
@@ -154,6 +158,7 @@ class IndexCommand extends Command
     {
         $packagesToDeleteFromIndex = [];
 
+        /** @noinspection PhpUndefinedMethodInspection */
         foreach ($this->index->browse('', ['attributesToRetrieve' => ['objectID']]) as $item) {
             // Check if object still exists in collected packages
             $objectID = $item['objectID'];
@@ -164,18 +169,20 @@ class IndexCommand extends Command
             }
         }
 
-        if (0 === \count($packagesToDeleteFromIndex)) {
+
+        $total = \count($packagesToDeleteFromIndex);
+
+        $this->output->writeln($total.' objects to delete from index', OutputInterface::VERBOSITY_VERBOSE);
+
+        if ($total > 0) {
+            $this->output->writeln(' - '.implode("\n - ", $packagesToDeleteFromIndex), OutputInterface::VERBOSITY_VERBOSE);
+        }
+
+        if ($dryRun || 0 === $total) {
             return;
         }
 
-        if (!$dryRun) {
-            $this->index->deleteObjects($packagesToDeleteFromIndex);
-        } else {
-            $this->output->writeln(
-                sprintf('Objects to delete from index: %s', json_encode($packagesToDeleteFromIndex)),
-                OutputInterface::VERBOSITY_DEBUG
-            );
-        }
+        $this->index->deleteObjects($packagesToDeleteFromIndex);
     }
 
     private function collectPackages(array $packageNames): void
@@ -189,7 +196,7 @@ class IndexCommand extends Command
             }
 
             $this->packages[$packageName] = $package;
-            $this->output->writeln('Added '.$packageName, OutputInterface::VERBOSITY_DEBUG);
+            $this->output->writeln($packageName.' added', OutputInterface::VERBOSITY_DEBUG);
         }
     }
 
@@ -205,41 +212,11 @@ class IndexCommand extends Command
         }
     }
 
-    private function indexPackages(bool $dryRun, bool $ignoreCache, bool $updateStats): void
+    private function indexPackages(bool $dryRun, array &$cache, bool $updateStats): void
     {
-        if (0 === \count($this->packages)) {
-            return;
-        }
+        $objectIDs = [];
 
-        $packages = [];
-
-        // Ignore the ones that do not need any update
-        foreach ($this->packages as $packageName => $package) {
-            $hash = self::CACHE_PREFIX.'-'.$package->getHash($updateStats);
-
-            $cacheItem = $this->cacheItemPool->getItem($hash);
-
-            if (!$ignoreCache) {
-                if (!$cacheItem->isHit()) {
-                    $hitMsg = 'miss';
-                    $cacheItem->set(true);
-                    $this->cacheItemPool->saveDeferred($cacheItem);
-                    $packages[] = $package;
-                } else {
-                    $hitMsg = 'hit';
-                }
-            } else {
-                $packages[] = $package;
-                $hitMsg = 'ignored';
-            }
-
-            $this->output->writeln(
-                sprintf('Cache entry for package "%s" was %s (hash: %s)', $packageName, $hitMsg, $hash),
-                OutputInterface::VERBOSITY_DEBUG
-            );
-        }
-
-        foreach (array_chunk($packages, 100) as $chunk) {
+        foreach (array_chunk($this->packages, 100) as $chunk) {
             $objects = [];
 
             /** @var Package $package */
@@ -253,23 +230,47 @@ class IndexCommand extends Command
                         $languages = array_merge(['en'], array_diff(self::LANGUAGES, $languageKeys));
                     }
 
-                    $objects[] = $package->getForAlgolia($languages);
+                    $data = $package->getForAlgolia($languages);
+                    $hash = $package->getHash($languages, $updateStats);
+
+                    if (isset($cache[$data['objectID']])) {
+                        $this->output->writeln(
+                            sprintf('Cache HIT for object %s', $data['objectID']),
+                            OutputInterface::VERBOSITY_DEBUG
+                        );
+
+                        if ($cache[$data['objectID']] === $hash) {
+                            continue;
+                        }
+
+                        $this->output->writeln(
+                            sprintf('Hash MISMATCH: old: %s / new: %s', $cache[$data['objectID']], $hash),
+                            OutputInterface::VERBOSITY_DEBUG
+                        );
+                    }
+
+                    $cache[$data['objectID']] = $hash;
+                    $objects[] = $data;
+                    $objectIDs[] = $data['objectID'];
+
+                    $this->output->writeln(
+                        sprintf('Cache MISS for object %s', $data['objectID']),
+                        OutputInterface::VERBOSITY_DEBUG
+                    );
                 }
             }
 
             if (!$dryRun) {
                 $this->index->saveObjects($objects);
-            } else {
-                $this->output->writeln(
-                    sprintf('Objects to index: %s', json_encode($objects)),
-                    OutputInterface::VERBOSITY_DEBUG
-                );
             }
         }
 
-        $this->output->writeln(sprintf('Updated "%s" package(s).', \count($packages)), OutputInterface::VERBOSITY_DEBUG);
+        $total = \count($objectIDs);
+        $this->output->writeln($total.' objects to index', OutputInterface::VERBOSITY_VERBOSE);
 
-        $this->cacheItemPool->commit();
+        if ($total > 0) {
+            $this->output->writeln(' - '.implode("\n - ", $objectIDs), OutputInterface::VERBOSITY_VERBOSE);
+        }
     }
 
     private function createIndex(bool $clearIndex): void
@@ -278,9 +279,11 @@ class IndexCommand extends Command
             return;
         }
 
+        /** @noinspection PhpUnhandledExceptionInspection */
         $this->index = $this->client->initIndex($_SERVER['ALGOLIA_INDEX']);
 
         if ($clearIndex) {
+            /** @noinspection PhpUnhandledExceptionInspection */
             $this->index->clearIndex();
         }
     }

--- a/indexer/src/Package/Package.php
+++ b/indexer/src/Package/Package.php
@@ -381,29 +381,14 @@ class Package
         });
     }
 
-    public function getHash(bool $includeStatistics = false): string
+    public function getHash(array $languages, bool $includeStatistics = true): string
     {
-        $info = [
-            $this->getName(),
-            $this->getDescription(),
-            $this->getKeywords(),
-            $this->getHomepage(),
-            $this->getSupport(),
-            $this->getVersions(),
-            $this->getLicense(),
-            $this->isSupported(),
-            $this->isDependency(),
-            $this->getAbandoned(),
-            $this->isPrivate(),
-            $this->getLogo(),
-            $this->getMeta(),
-        ];
+        $data = $this->getForAlgolia($languages);
 
-        if ($includeStatistics) {
-            $info[] = $this->getFavers();
-            $info[] = $this->getDownloads();
+        if (!$includeStatistics) {
+            unset($data['favers'], $data['downloads']);
         }
 
-        return sha1(json_encode($info));
+        return sha1(json_encode($data));
     }
 }


### PR DESCRIPTION
I had to disable the cronjob yesterday because it caused too many updates. Found out that the GitHub Actions cache is not meant for a regular persistent cache, but for stuff like dependencies. I've simplified it to a PHP file cache and we're using the commit SHA to make sure the cache is updated on every run.