### PR TITLE
Fix some packages being marked as private

### DIFF
--- a/indexer/index
+++ b/indexer/index
@@ -28,7 +28,7 @@ $packagist = new Packagist($output, $httpClient);
 $metadataRepository = new MetaDataRepository(dirname(__DIR__).'/meta');
 $packageFactory = new Factory($metadataRepository, $packagist);
 $algoliaClient = new Client($_SERVER['ALGOLIA_APP_ID'], $_SERVER['ALGOLIA_API_KEY']);
-$command = new IndexCommand($packagist, $packageFactory, $algoliaClient, $metadataRepository, __DIR__.'/cache/packages.php');
+$command = new IndexCommand($packagist, $packageFactory, $algoliaClient, $metadataRepository);
 
 $application = new Application();
 $application->add($command);

--- a/indexer/src/Package/Factory.php
+++ b/indexer/src/Package/Factory.php
@@ -41,6 +41,8 @@ class Factory
 
     public function create(string $name): Package
     {
+        // Package names are case-insensitive and returned lowercase from Packagist
+        $name = strtolower($name);
         $cacheKey = 'basic-'.$name;
 
         if (isset($this->cache[$cacheKey])) {

--- a/indexer/src/Packagist.php
+++ b/indexer/src/Packagist.php
@@ -61,6 +61,8 @@ class Packagist
         }
 
         try {
+            // Package names are lowercase in the result set
+            $name = strtolower($name);
             $packagesData = $this->getJson('https://packagist.org/packages/'.$name.'.json');
 
             if (!isset($packagesData['package'])) {

--- a/indexer/src/Packagist.php
+++ b/indexer/src/Packagist.php
@@ -61,8 +61,6 @@ class Packagist
         }
 
         try {
-            // Package names are lowercase in the result set
-            $name = strtolower($name);
             $packagesData = $this->getJson('https://packagist.org/packages/'.$name.'.json');
 
             if (!isset($packagesData['package'])) {

--- a/indexer/src/Packagist.php
+++ b/indexer/src/Packagist.php
@@ -21,9 +21,9 @@ class Packagist
     private const PLATFORM_PACKAGE_REGEX = '{^(?:php(?:-64bit|-ipv6|-zts|-debug)?|hhvm|(?:ext|lib)-[^/ ]+)$}i';
 
     /**
-     * Blacklisted packages that should not be found.
+     * Excluded packages that should not be found.
      */
-    private const BLACKLIST = ['contao/installation-bundle', 'contao/module-devtools', 'contao/module-repository', 'contao/contao'];
+    private const EXCLUDE_LIST = ['contao/installation-bundle', 'contao/module-devtools', 'contao/module-repository', 'contao/contao'];
 
     /**
      * @var OutputInterface
@@ -51,7 +51,7 @@ class Packagist
             return [];
         }
 
-        return array_diff($data['packageNames'], self::BLACKLIST);
+        return array_diff($data['packageNames'], self::EXCLUDE_LIST);
     }
 
     public function getPackageData(string $name): ?array


### PR DESCRIPTION
This PR, especially commit dd53f6cb5c6706bb3c8c5c19063d674c76545e36, fixes the issue that some packages are being marked as private, even if they are available on Packagist.

This is the case when some packages use uppercase characters in their name. The Packagist API returns the name in lowecase then and the indexer fails to process them.