### PR TITLE
Do not use `::set-env` anymore

### DIFF
--- a/.github/workflows/index-on-push.yaml
+++ b/.github/workflows/index-on-push.yaml
@@ -35,7 +35,7 @@ jobs:
 
             - name: extract-packages
               run: |
-                  echo "::set-env name=packages::$(git diff --name-only HEAD~..HEAD -- | grep -E "^meta/[^/]+/[^/]+/.+?\.(yml|json)" | sed -E 's/meta\/([^\/]+\/[^\/]+)\/[^\/]+$/\1/' | uniq | tr '\n' ' ')"
+                  echo "packages=$(git diff --name-only HEAD~..HEAD -- | grep -E "^meta/[^/]+/[^/]+/.+?\.(yml|json)" | sed -E 's/meta\/([^\/]+\/[^\/]+)\/[^\/]+$/\1/' | uniq | tr '\n' ' ')" >> $GITHUB_ENV
 
             - name: Update Index
               if: env.packages

--- a/.github/workflows/index-scheduled.yaml
+++ b/.github/workflows/index-scheduled.yaml
@@ -31,7 +31,7 @@ jobs:
             # Update statistics twice a day (24 * 30 mins = 12h)
             - name: with-stats
               run: |
-                  echo "::set-env name=with_stats::$(expr ${{ github.run_number }} % 24)"
+                  echo "with_stats=$(expr ${{ github.run_number }} % 24)" >> $GITHUB_ENV
 
             - name: Update Index
               run: indexer/index -v ${{ env.with_stats == 0 && '--with-stats' || '' }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,7 +35,7 @@ jobs:
 
             - name: Find changed files
               run: |
-                  echo "::set-env name=metafiles::$(git diff --name-only origin/main -- | grep -E "^meta/[^/]+/[^/]+/.+?\.(yml|json)" | uniq | tr '\n' ' ')"
+                  echo "metafiles=$(git diff --name-only origin/main -- | grep -E "^meta/[^/]+/[^/]+/.+?\.(yml|json)" | uniq | tr '\n' ' ')" >> $GITHUB_ENV
 
             - name: Lint files
               run: linter/lint ${{ env.metafiles }}


### PR DESCRIPTION
More details:
 - https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
 - https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable