### PR TITLE
Remove dependency and add descriptions for codefog/contao-haste

### DIFF
--- a/meta/codefog/contao-haste/de.yml
+++ b/meta/codefog/contao-haste/de.yml
@@ -1,4 +1,4 @@
 de:
     title: Contao Haste
     description: >
-        Haste is eine Sammlung an Werkzeugen und Klassen für Entwickler um das Arbeiten mit Contao zu erleichtern. Die Erweiterung enthält außerdem eine Sammlung an zusätzlichen Insert-Tags, die an verschiedenen Stellen nützlich sein können, wie zum Beispiel das konvertieren oder formatieren von Datumsangaben. Nähere Informationen zu den Möglichkeiten der Extension findet man in der Dokumentation auf GitHub.
+        Haste ist eine Sammlung an Werkzeugen und Klassen für Entwickler um das Arbeiten mit Contao zu erleichtern. Die Erweiterung enthält außerdem eine Sammlung an zusätzlichen Insert-Tags, die an verschiedenen Stellen nützlich sein können, wie zum Beispiel das konvertieren oder formatieren von Datumsangaben. Nähere Informationen zu den Möglichkeiten der Extension findet man in der Dokumentation auf GitHub.

--- a/meta/codefog/contao-haste/de.yml
+++ b/meta/codefog/contao-haste/de.yml
@@ -1,0 +1,4 @@
+de:
+    title: Contao Haste
+    description: >
+        Haste is eine Sammlung an Werkzeugen und Klassen für Entwickler um das Arbeiten mit Contao zu erleichtern. Die Erweiterung enthält außerdem eine Sammlung an zusätzlichen Insert-Tags, die an verschiedenen Stellen nützlich sein können, wie zum Beispiel das konvertieren oder formatieren von Datumsangaben. Nähere Informationen zu den Möglichkeiten der Extension findet man in der Dokumentation auf GitHub.

--- a/meta/codefog/contao-haste/en.yml
+++ b/meta/codefog/contao-haste/en.yml
@@ -1,4 +1,4 @@
 en:
     title: Contao Haste
     description: >
-        Haste is a collection of tools and classes to ease working with Contao. The extension also provides a collection of insert tags which can be useful for different purposes, e.g. converting for formatting dates. Further information about all the features of this extension can be found on GitHub.
+        Haste is a collection of tools and classes to ease working with Contao. The extension also provides a collection of insert tags which can be useful for different purposes, e.g. converting or formatting dates. Further information about all the features of this extension can be found on GitHub.

--- a/meta/codefog/contao-haste/en.yml
+++ b/meta/codefog/contao-haste/en.yml
@@ -1,2 +1,4 @@
 en:
-    dependency: true
+    title: Contao Haste
+    description: >
+        Haste is a collection of tools and classes to ease working with Contao. The extension also provides a collection of insert tags which can be useful for different purposes, e.g. converting for formatting dates. Further information about all the features of this extension can be found on GitHub.


### PR DESCRIPTION
Since `codefog/contao-haste` is not just aimed at developers but also "end users" (useful insert tags for example), it should not be marked as a dependency package and should instead provide a more detailed description.