### PR TITLE
Added 'hotspot' to the allowlist

### DIFF
--- a/linter/allowlists/en.txt
+++ b/linter/allowlists/en.txt
@@ -88,6 +88,7 @@ Head
 HeaderFooterCode
 helpdesk
 History
+hotspot
 infos
 Insert
 Install


### PR DESCRIPTION
Seems this word was killing me during spellcheck, added it to the approved list of words.