### PR TITLE
Allow spellchecker to fail on PRs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,7 +5,7 @@ on:
         paths:
             - 'meta/**'
     schedule:
-        - cron: '0 12 1 * *'
+        - cron: '0 12 * * 1'
 
 jobs:
     lint:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,5 +37,9 @@ jobs:
               run: |
                   echo "metafiles=$(git diff --name-only origin/main -- | grep -E "^meta/[^/]+/[^/]+/.+?\.(yml|json)" | uniq | tr '\n' ' ')" >> $GITHUB_ENV
 
-            - name: Lint files
+            - name: Lint files without spell check
+              run: linter/lint --skip-spell-check ${{ env.metafiles }}
+
+            - name: Lint files with spell check
               run: linter/lint ${{ env.metafiles }}
+              continue-on-error: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
The goal is to simplify contribution to this repository.
The spell checker requires some knowledge and while it's a great addition to ensure the quality, we should not hard fail on pull requests if they do not pass. The checks can still report the issues but it should be okay to fail for pull requests.
We should not fail on cron jobs though so that one of the repository owners can fix the issues.

Only the spell checker is allowed to fail. All the other checks still have to pass (invalid YAML format etc. must be fixed by the contributors).