### PR TITLE
Check for file existence

### DIFF
--- a/linter/src/LintCommand.php
+++ b/linter/src/LintCommand.php
@@ -83,7 +83,7 @@ class LintCommand extends Command
     private function validateFiles(array $files, bool $skipPrivate, bool $skipSpellCheck): void
     {
         foreach ($files as $path) {
-            $file = new \SplFileInfo(realpath($path) ?: '');
+            $file = new \SplFileInfo(realpath($path) ?: $path);
 
             if (!$file->isFile()) {
                 continue;

--- a/linter/src/LintCommand.php
+++ b/linter/src/LintCommand.php
@@ -83,11 +83,9 @@ class LintCommand extends Command
     private function validateFiles(array $files, bool $skipPrivate, bool $skipSpellCheck): void
     {
         foreach ($files as $path) {
-            $file = new \SplFileInfo(realpath($path));
+            $file = new \SplFileInfo(realpath($path) ?: '');
 
             if (!$file->isFile()) {
-                $this->io->error(sprintf('The file "%s" was not found', $path));
-                $this->error = true;
                 continue;
             }
 


### PR DESCRIPTION
Fixes #410 

If a PR removes a file, the linter will fail:

```
Fatal error:  Uncaught TypeError: SplFileInfo::__construct() expects parameter 1 to be a valid path, bool given in /home/runner/work/package-metadata/package-metadata/linter/src/LintCommand.php:86

Fatal error: Uncaught TypeError: SplFileInfo::__construct() expects parameter 1 to be a valid path, bool given in /home/runner/work/package-metadata/package-metadata/linter/src/LintCommand.php:86
Stack trace:
#0 /home/runner/work/package-metadata/package-metadata/linter/src/LintCommand.php(86): SplFileInfo->__construct()
#1 /home/runner/work/package-metadata/package-metadata/linter/src/LintCommand.php(68): Contao\PackageMetaDataLinter\LintCommand->validateFiles()
#2 /home/runner/work/package-metadata/package-metadata/linter/vendor/symfony/console/Command/Command.php(255): Contao\PackageMetaDataLinter\LintCommand->execute()
#3 /home/runner/work/package-metadata/package-metadata/linter/vendor/symfony/console/Application.php(1009): Symfony\Component\Console\Command\Command->run()
#4 /home/runner/work/package-metadata/package-metadata/linter/vendor/symfony/console/Application.php(273): Symfony\Component\Console\Application->doRunCommand()
#5 /home/runner/work/package-metadata/package-metadata/linter/vendor/symfony/console/App in /home/runner/work/package-metadata/package-metadata/linter/src/LintCommand.php on line 86
```

The `$file->isFile` check never works, because `realpath` will already return `false` if the file does not exist. Hence this error occurs. This PR fixes that by providing an empty string to `SplFileInfo` in such a case.

This PR also removes the error when a file was not found, as this is not helpful information if a PR deliberately removes a file.