### PR TITLE
Added meta information for Contao Redirect Failed Login package

### DIFF
--- a/meta/bright-cloud-studio/contao-redirect-failed-login/en.yml
+++ b/meta/bright-cloud-studio/contao-redirect-failed-login/en.yml
@@ -1,0 +1,15 @@
+en:
+    title: Contao Redirect Failed Login
+    description: >
+        Extends the default Contao 'Login form' front end module to allow selecting of a page to foward users to after failed login attempts
+    keywords:
+        - login
+        - fail
+        - redirect
+        - bright
+        - cloud
+        - studio
+    support:
+        email: mark@brightcloudstudio.com
+        issues: https://github.com/bright-cloud-studio/contao-redirect-failed-login/issues
+        source: https://github.com/bright-cloud-studio/contao-redirect-failed-login

--- a/meta/bright-cloud-studio/contao-redirect-failed-login/en.yml
+++ b/meta/bright-cloud-studio/contao-redirect-failed-login/en.yml
@@ -1,7 +1,7 @@
 en:
     title: Contao Redirect Failed Login
     description: >
-        Extends the default Contao 'Login form' front end module to allow selecting of a page to foward users to after failed login attempts
+        Extends the default Contao 'Login form' front end module to allow selecting of a page to forward users to after failed login attempts
     keywords:
         - login
         - fail


### PR DESCRIPTION
I've created a new package for Contao that allows users to select a page to forward users to if they fail a login attempt. This was needed for a client but I figured others might get use out of it.