### PR TITLE
Add bwein-net/contao-system-information

### DIFF
--- a/meta/bwein-net/contao-system-information/de.yml
+++ b/meta/bwein-net/contao-system-information/de.yml
@@ -1,0 +1,15 @@
+de:
+    title: System-Information
+    description: >
+        Mit dieser Erweiterung können im Backend verschiedene grundlegende Fakten zur Umgebung, in der die aktuelle Contao-Instanz läuft, angezeigt werden.
+        Enthalten sind: Informationen zu PHP, Datenbank, Betriebssystem, Host, Hardware, Virtualisierung und Systemlast (einschließlich eines Live-Diagramms zur Systemlast).
+    keywords:
+        - contao
+        - back end
+        - environment
+        - system
+        - information
+        - info
+        - host
+        - hardware
+        - load

--- a/meta/bwein-net/contao-system-information/en.yml
+++ b/meta/bwein-net/contao-system-information/en.yml
@@ -1,0 +1,15 @@
+en:
+    title: System Information
+    description: >
+        This bundle allows you to view different basic facts about the environment your Contao instance is running in,
+        like information about PHP, database, operating system, host, hardware, virtualization and system load (including a live system load graph).
+    keywords:
+        - contao
+        - back end
+        - environment
+        - system
+        - information
+        - info
+        - host
+        - hardware
+        - load


### PR DESCRIPTION
The extension `eikona-media/contao-system-information` is no longer maintained, so I want to add my maintained fork.