### PR TITLE
Add presprog/contao-password-suggestion metadata

### DIFF
--- a/meta/presprog/contao-password-suggestion/de.yml
+++ b/meta/presprog/contao-password-suggestion/de.yml
@@ -1,0 +1,10 @@
+de:
+    title: Contao Password Suggestion
+    description: >
+        Erweitert die Benutzer- und Mitgliederverwaltung im Backend um einen One-Click Passwortgenerator, um das Anlegen neuer Benutzer:innen und Mitglieder zu vereinfachen.
+    keywords:
+        - Passwort
+        - Backend
+        - Benutzer
+        - Mitglieder
+        - Passwortgenerator

--- a/meta/presprog/contao-password-suggestion/en.yml
+++ b/meta/presprog/contao-password-suggestion/en.yml
@@ -1,0 +1,10 @@
+en:
+    title: Contao Password Suggestion
+    description: >
+        Adds a one-click password generator to the backend user and member management to simplify adding new users and members.
+    keywords:
+        - Password
+        - Back-end
+        - User
+        - Member
+        - Password generator


### PR DESCRIPTION
We un-abandoned our password suggestion extension and fixed it for Contao 4.13 
https://packagist.org/packages/presprog/contao-password-suggestion