### PR TITLE
Update contao-thememanager metadata

### DIFF
--- a/linter/allowlists/de.txt
+++ b/linter/allowlists/de.txt
@@ -711,7 +711,6 @@ ThemeRoller
 Ticker
 tiles
 Tiles
-TinySlider
 Titelleiste
 tmp
 Toolbox

--- a/linter/allowlists/en.txt
+++ b/linter/allowlists/en.txt
@@ -165,7 +165,6 @@ theming
 Ticker
 tiles
 Tiles
-TinySlider
 tmp
 Tracking
 Trigger

--- a/meta/contao-thememanager/ctm-estatemanager/de.yml
+++ b/meta/contao-thememanager/ctm-estatemanager/de.yml
@@ -1,0 +1,7 @@
+de:
+    title: 'ThemeManager: EstateManager'
+    description: >
+        Integriert den Contao EstateManager und seine Erweiterungen in den Contao ThemeManager.
+    keywords:
+        - immobilien
+        - theme

--- a/meta/contao-thememanager/ctm-estatemanager/en.yml
+++ b/meta/contao-thememanager/ctm-estatemanager/en.yml
@@ -1,0 +1,7 @@
+en:
+    title: 'ThemeManager: EstateManager'
+    description: >
+        Integrates the Contao EstateManager and its extensions into the Contao ThemeManager.
+    keywords:
+        - realestate
+        - theme

--- a/meta/contao-thememanager/ctm-recommendation/de.yml
+++ b/meta/contao-thememanager/ctm-recommendation/de.yml
@@ -1,8 +1,8 @@
 de:
     title: 'ThemeManager: Bewertungen'
     description: >
-        Integriert das Contao Bewertungen Bundle in den Contao ThemeManager, indem es neue Vorlagen bereitstellt und
-        Erweiterung der Module und Komponenten um neue Optionen.
+        Integriert das Contao Bewertungen Bundle in den Contao ThemeManager, indem es neue Templates bereitstellt und
+        die Module und Komponenten um neue Optionen erweitert.
     keywords:
         - theme
         - bewertungen

--- a/meta/contao-thememanager/ctm-tiny-slider/de.yml
+++ b/meta/contao-thememanager/ctm-tiny-slider/de.yml
@@ -1,7 +1,7 @@
 de:
-    title: 'ThemeManager: TinySlider'
+    title: 'ThemeManager: Tiny Slider'
     description: >
-        Integriert den TinySlider in den Contao ThemeManager und erweitert Listen, Wrapper, Galerien und
+        Integriert den Tiny Slider in den Contao ThemeManager und erweitert Listen, Wrapper, Galerien und
         weitere Komponenten mit neuen Optionen.
     keywords:
         - theme

--- a/meta/contao-thememanager/ctm-tiny-slider/en.yml
+++ b/meta/contao-thememanager/ctm-tiny-slider/en.yml
@@ -1,7 +1,7 @@
 en:
-    title: 'ThemeManager: TinySlider'
+    title: 'ThemeManager: Tiny Slider'
     description: >
-        Integrates the TinySlider into the Contao ThemeManager by enhancing list components, wrappers, galleries and
+        Integrates the Tiny Slider into the Contao ThemeManager by enhancing list components, wrappers, galleries and
         more components with new options.
     keywords:
         - theme


### PR DESCRIPTION
<h3>Fixes</h3>

- fixed german description of ctm-recommendation aff96004627389c69480061b0f9d32a7031590b9
- fixed description of ctm-tiny-slider 04791b60957cbcd789381694c2dcdf006f705d4e
  - renamed TinySlider to it's package name "Tiny Slider" (See: https://github.com/ganlanyuan/tiny-slider)
  - removed previously added TinySlider from allowlists (See: https://github.com/contao/package-metadata/pull/508/commits/89137df4710dee1dba7fb1a2a63e9f1f98b895f7)

<h3>Addition</h3>

- added metadata for contao-thememanager/ctm-estatemanager 29e7a29a3214ea1d7de74297f6e3604c945e4a6d