### PR TITLE
Store compatible Contao version range

### DIFF
--- a/indexer/composer.json
+++ b/indexer/composer.json
@@ -19,6 +19,7 @@
         "ext-json": "*",
         "algolia/algoliasearch-client-php": "^1.27",
         "composer/metadata-minifier": "^1.0",
+        "composer/semver": "^3.4",
         "symfony/console": "^6.0",
         "symfony/finder": "^6.0",
         "symfony/filesystem": "^6.0",

--- a/indexer/composer.lock
+++ b/indexer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a8d168630f433c608410829462fe3ed",
+    "content-hash": "e1a7a5692a89380a93f86e4dff96abe6",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -129,6 +129,87 @@
                 }
             ],
             "time": "2021-04-07T13:37:33+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "c51258e759afdb17f1fd1fe83bc12baaef6309d6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c51258e759afdb17f1fd1fe83bc12baaef6309d6",
+                "reference": "c51258e759afdb17f1fd1fe83bc12baaef6309d6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.4",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-07-12T11:35:52+00:00"
         },
         {
             "name": "psr/container",
@@ -1827,5 +1908,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/indexer/src/Package/Factory.php
+++ b/indexer/src/Package/Factory.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Contao\PackageMetaDataIndexer\Package;
 
+use Composer\Semver\Constraint\Constraint;
+use Composer\Semver\Constraint\MultiConstraint;
+use Composer\Semver\Intervals;
+use Composer\Semver\VersionParser;
 use Contao\PackageMetaDataIndexer\Command\IndexCommand;
 use Contao\PackageMetaDataIndexer\MetaDataRepository;
 use Contao\PackageMetaDataIndexer\Packagist;
@@ -11,6 +15,8 @@ use Contao\PackageMetaDataIndexer\Packagist;
 class Factory
 {
     private array $cache = [];
+
+    private array $contaoVersions = [];
 
     public function __construct(private readonly MetaDataRepository $metaData, private readonly Packagist $packagist)
     {
@@ -78,6 +84,8 @@ class Factory
         $versions = array_keys($data['packages']['versions']);
         // $data['p'] contains the non-cached data, while only $data['packages'] has the "support" metadata
         $latestPackages = $this->findLatestVersion($data['packages']['versions']);
+        $contaoConstraint = $this->buildContaoConstraint($data['p']);
+        $contaoVersions = $this->buildContaoVersions($contaoConstraint);
 
         sort($versions);
 
@@ -96,6 +104,8 @@ class Factory
         $package->setSupported($this->isSupported($data['packages']['versions']));
         $package->setAbandoned($data['packages']['abandoned'] ?? false);
         $package->setSuggest($latest['suggest'] ?? null);
+        $package->setContaoConstraint($contaoConstraint);
+        $package->setContaoVersions($contaoVersions);
         $package->setPrivate(false);
     }
 
@@ -168,5 +178,78 @@ class Factory
         );
 
         return $versions[$latest] ?? [];
+    }
+
+    private function buildContaoConstraint(array $versions): string
+    {
+        $constraints = [];
+
+        foreach ($versions as $package) {
+            if (!$constraint = $package['require']['contao/core-bundle'] ?? null) {
+                continue;
+            }
+
+            if ('self.version' === $constraint) {
+                $constraint = $package['version'];
+            }
+
+            try {
+                $constraints[] = (new VersionParser())->parseConstraints($constraint);
+            } catch (\Throwable) {
+                // Ignore
+            }
+        }
+
+        return str_replace(['[', ']'], '', (string) Intervals::compactConstraint(MultiConstraint::create($constraints, false)));
+    }
+
+    private function buildContaoVersions(string $contaoConstraint): array
+    {
+        if (!$this->contaoVersions) {
+            $data = $this->packagist->getPackageData('contao/core-bundle');
+
+            foreach ($data['p'] as $package) {
+                $version = explode('.', (new VersionParser())->normalize($package['version'] ?? ''));
+
+                if (\count($version) > 3 && (int) $version[0]) {
+                    $this->contaoVersions[(int) $version[0]][(int) $version[1]] ??= implode('.', $version);
+                }
+            }
+
+            ksort($this->contaoVersions);
+
+            foreach ($this->contaoVersions as $major => $minors) {
+                ksort($this->contaoVersions[$major]);
+            }
+        }
+
+        $constraint = (new VersionParser())->parseConstraints($contaoConstraint);
+
+        $matches = [];
+
+        foreach ($this->contaoVersions as $major => $minors) {
+            $prefix = '';
+            $lastMinor = 0;
+
+            foreach ($minors as $minor => $versionString) {
+                if ($constraint->matches(new Constraint('=', $versionString))) {
+                    if (!$prefix) {
+                        $prefix = "$major.$minor";
+                    }
+                } elseif ($prefix) {
+                    $version = "$major.$lastMinor";
+                    $matches[] = $version === $prefix ? $version : "$prefix - $version";
+                    $prefix = '';
+                }
+
+                $lastMinor = $minor;
+            }
+
+            if ($prefix) {
+                $matches[] = "$prefix +";
+            }
+        }
+
+        return $matches;
     }
 }

--- a/indexer/src/Package/Factory.php
+++ b/indexer/src/Package/Factory.php
@@ -246,7 +246,7 @@ class Factory
             }
 
             if ($prefix) {
-                $matches[] = "$prefix +";
+                $matches[] = "$prefix+";
             }
         }
 

--- a/indexer/src/Package/Package.php
+++ b/indexer/src/Package/Package.php
@@ -24,6 +24,8 @@ class Package
     private string|bool $abandoned = false;
     private bool $private = false;
     private array|null $suggest = null;
+    private string $contaoConstraint = '';
+    private array $contaoVersions = [];
     private string|null $logo = null;
     private array $meta = [];
 
@@ -252,6 +254,30 @@ class Package
         return $this;
     }
 
+    public function getContaoConstraint(): string
+    {
+        return $this->contaoConstraint;
+    }
+
+    public function setContaoConstraint(string $contaoConstraint): self
+    {
+        $this->contaoConstraint = $contaoConstraint;
+
+        return $this;
+    }
+
+    public function getContaoVersions(): array
+    {
+        return $this->contaoVersions;
+    }
+
+    public function setContaoVersions(array $contaoVersions): self
+    {
+        $this->contaoVersions = $contaoVersions;
+
+        return $this;
+    }
+
     public function getLogo(): string|null
     {
         return $this->logo;
@@ -310,6 +336,8 @@ class Package
             'abandoned' => $this->getAbandoned(),
             'private' => $this->isPrivate(),
             'suggest' => $this->getSuggest(),
+            'contaoConstraint' => $this->getContaoConstraint(),
+            'contaoVersions' => $this->getContaoVersions(),
             'logo' => $this->getLogo(),
             'languages' => $languages,
         ];


### PR DESCRIPTION
As discussed in yesterdays call, this adds two new fields:

```json
"contaoConstraint": ">= 4.4.4.0-dev < 5.0.0.0-dev || >= 5.2.0.0-dev < 6.0.0.0-dev",
"contaoVersions": ["4.4 +", "5.2 +"],
```