### PR TITLE
Skip unstable packages for calculation the Contao versions

### DIFF
--- a/indexer/src/Package/Factory.php
+++ b/indexer/src/Package/Factory.php
@@ -185,6 +185,10 @@ class Factory
         $constraints = [];
 
         foreach ($versions as $package) {
+            if (VersionParser::parseStability($package['version']) !== 'stable') {
+                continue;
+            }
+
             if (!$constraint = $package['require']['contao/core-bundle'] ?? null) {
                 continue;
             }


### PR DESCRIPTION
Only stable versions should be considered for calculationg the “compatbile” Contao versions.