### PR TITLE
Do not build versions for non-Contao packages

### DIFF
--- a/indexer/src/Package/Factory.php
+++ b/indexer/src/Package/Factory.php
@@ -85,7 +85,7 @@ class Factory
         // $data['p'] contains the non-cached data, while only $data['packages'] has the "support" metadata
         $latestPackages = $this->findLatestVersion($data['packages']['versions']);
         $contaoConstraint = $this->buildContaoConstraint($data['p']);
-        $contaoVersions = $this->buildContaoVersions($contaoConstraint);
+        $contaoVersions = $contaoConstraint ? $this->buildContaoVersions($contaoConstraint) : null;
 
         sort($versions);
 
@@ -180,7 +180,7 @@ class Factory
         return $versions[$latest] ?? [];
     }
 
-    private function buildContaoConstraint(array $versions): string
+    private function buildContaoConstraint(array $versions): string|null
     {
         $constraints = [];
 
@@ -201,7 +201,7 @@ class Factory
         }
 
         if (!$constraints) {
-            return '';
+            return null;
         }
 
         return str_replace(['[', ']'], '', (string) Intervals::compactConstraint(MultiConstraint::create($constraints, false)));
@@ -209,10 +209,6 @@ class Factory
 
     private function buildContaoVersions(string $contaoConstraint): array
     {
-        if (!$contaoConstraint) {
-            return [];
-        }
-
         if (!$this->contaoVersions) {
             $data = $this->packagist->getPackageData('contao/core-bundle');
 

--- a/indexer/src/Package/Factory.php
+++ b/indexer/src/Package/Factory.php
@@ -200,11 +200,19 @@ class Factory
             }
         }
 
+        if (!$constraints) {
+            return '';
+        }
+
         return str_replace(['[', ']'], '', (string) Intervals::compactConstraint(MultiConstraint::create($constraints, false)));
     }
 
     private function buildContaoVersions(string $contaoConstraint): array
     {
+        if (!$contaoConstraint) {
+            return [];
+        }
+
         if (!$this->contaoVersions) {
             $data = $this->packagist->getPackageData('contao/core-bundle');
 

--- a/indexer/src/Package/Package.php
+++ b/indexer/src/Package/Package.php
@@ -24,8 +24,8 @@ class Package
     private string|bool $abandoned = false;
     private bool $private = false;
     private array|null $suggest = null;
-    private string $contaoConstraint = '';
-    private array $contaoVersions = [];
+    private string|null $contaoConstraint = null;
+    private array|null $contaoVersions = null;
     private string|null $logo = null;
     private array $meta = [];
 
@@ -254,24 +254,24 @@ class Package
         return $this;
     }
 
-    public function getContaoConstraint(): string
+    public function getContaoConstraint(): string|null
     {
         return $this->contaoConstraint;
     }
 
-    public function setContaoConstraint(string $contaoConstraint): self
+    public function setContaoConstraint(string|null $contaoConstraint): self
     {
         $this->contaoConstraint = $contaoConstraint;
 
         return $this;
     }
 
-    public function getContaoVersions(): array
+    public function getContaoVersions(): array|null
     {
         return $this->contaoVersions;
     }
 
-    public function setContaoVersions(array $contaoVersions): self
+    public function setContaoVersions(array|null $contaoVersions): self
     {
         $this->contaoVersions = $contaoVersions;
 
@@ -336,11 +336,17 @@ class Package
             'abandoned' => $this->getAbandoned(),
             'private' => $this->isPrivate(),
             'suggest' => $this->getSuggest(),
-            'contaoConstraint' => $this->getContaoConstraint(),
-            'contaoVersions' => $this->getContaoVersions(),
             'logo' => $this->getLogo(),
             'languages' => $languages,
         ];
+
+        if ($this->getContaoConstraint()) {
+            $data['contaoConstraint'] = $this->getContaoConstraint();
+        }
+
+        if ($this->getContaoVersions()) {
+            $data['contaoVersions'] = $this->getContaoVersions();
+        }
 
         $data = array_replace_recursive($data, $this->getMetaForLanguage($language));
 


### PR DESCRIPTION
Packages like `twig/twig` should have empty values for `contaoConstraint` and `contaoVersions`