### PR TITLE
Do not define MCW as a dependency

### DIFF
--- a/meta/menatwork/contao-multicolumnwizard-bundle/de.yml
+++ b/meta/menatwork/contao-multicolumnwizard-bundle/de.yml
@@ -11,4 +11,3 @@ de:
         - wizard
         - multicolumnwizard
         - mcw
-    dependency: true

--- a/meta/menatwork/contao-multicolumnwizard-bundle/en.yml
+++ b/meta/menatwork/contao-multicolumnwizard-bundle/en.yml
@@ -11,4 +11,3 @@ en:
         - wizard
         - multicolumnwizard
         - mcw
-    dependency: true


### PR DESCRIPTION
As mentioned [before](https://github.com/contao/package-metadata/pull/129) there are users who want to install the MCW via the Contao Manager, as they do customize their application with it - but otherwise do not touch the `composer.json` themselves or run composer updates on the command line.

Most recent example: https://community.contao.org/de/showthread.php?87438-Contao-5-3-und-multicolumnwizard