### PR TITLE
List solo-contao-theme instead of solo-theme-bundle

### DIFF
--- a/meta/erdmannfreunde/solo-contao-theme/composer.json
+++ b/meta/erdmannfreunde/solo-contao-theme/composer.json
@@ -1,0 +1,34 @@
+{
+  "name": "erdmannfreunde/solo-contao-theme",
+  "description": "SOLO Theme SE",
+  "homepage": "https://erdmann-freunde.de/contao-themes/solo/",
+  "keywords": [
+    "contao",
+    "erdmannfreunde",
+    "solo",
+    "theme"
+  ],
+  "type": "contao-theme",
+  "license": "proprietary",
+  "authors": [
+    {
+      "name": "Erdmann & Freunde",
+      "homepage": "https://erdmann-freunde.de"
+    }
+  ],
+  "support": {
+    "homepage": "https://erdmann-freunde.de"
+  },
+  "require": {
+    "php": "^8.1",
+    "contao/manager-bundle": "5.3.*",
+    "contao/calendar-bundle": "^5.3",
+    "contao/comments-bundle": "^5.3",
+    "contao/conflicts": "@dev",
+    "contao/faq-bundle": "^5.3",
+    "contao/listing-bundle": "^5.3",
+    "contao/news-bundle": "^5.3",
+    "contao/newsletter-bundle": "^5.3",
+    "erdmannfreunde/solo-theme-bundle": "^3.0"
+  }
+}

--- a/meta/erdmannfreunde/solo-contao-theme/de.yml
+++ b/meta/erdmannfreunde/solo-contao-theme/de.yml
@@ -1,0 +1,24 @@
+de:
+    title: SOLO-Theme
+    description: >
+        SOLO ist ein Contao Theme für Agenturen, mit dem du eine professionelle Website für Solopreneure erstellen kannst.
+        Es ist perfekt für Musiker:innen, Sportler:innen, Autor:innen, Coaches und viele weitere Einzelpersonen.
+
+        SOLO basiert auf dem [Nutshell Framework](https://github.com/nutshell-framework) und wurde in Version 3 speziell für Contao 5.3 LTS entwickelt.
+        Das Theme ist für alle gängigen Geräte (Smartphones, Tablets, Desktop) und Browser (Chrome, Firefox, MS Edge, Safari) optimiert.
+
+        Besonderheiten von SOLO sind unter anderem
+
+        einfache Installation über den Contao Manager oder das Contao Backend,
+        einfache Farbanpassungen über Custom Properties (CSS Variablen) vielseitige Anpassungsmöglichkeiten über SCSS,
+        Gestaltung aller Standard-Inhaltselemente, Hero-Element mit Varianten für Schriftgröße und Schriftpositionierung,
+        keine Copyright- oder Backlink-Pflicht notwendig.
+
+        SOLO nutzt die neuen verschachtelten Inhaltselemente für Akkordeon und Slider
+    keywords:
+        - SOLO
+        - Theme
+        - Template
+        - scss
+        - Layout
+        - Erdmann und Freunde

--- a/meta/erdmannfreunde/solo-contao-theme/en.yml
+++ b/meta/erdmannfreunde/solo-contao-theme/en.yml
@@ -1,0 +1,24 @@
+en:
+    title: SOLO theme
+    description: >
+        SOLO is a Contao theme for agencies that allows you to create a professional website for solopreneurs.
+        It is perfect for musicians, athletes, authors, coaches and many other individuals.
+
+        SOLO is based on the [Nutshell Framework](https://github.com/nutshell-framework) and was developed in version 3 especially for Contao 5.3 LTS.
+        The theme is optimized for all common devices (smartphones, tablets, desktop) and browsers (Chrome, Firefox, MS Edge, Safari).
+
+        Special features of SOLO include
+
+        Easy installation via the Contao Manager or the Contao backend,
+        simple color adjustments via custom properties (CSS variables) versatile customization options via SCSS,
+        design of all standard content elements, hero element with variants for font size and positioning,
+        no copyright or backlink obligation necessary.
+
+        SOLO uses the new nested content elements for accordion and slider
+    keywords:
+        - SOLO
+        - Theme
+        - Template
+        - scss
+        - Layout
+        - Erdmann und Freunde

--- a/meta/erdmannfreunde/solo-theme-bundle/de.yml
+++ b/meta/erdmannfreunde/solo-theme-bundle/de.yml
@@ -1,24 +1,3 @@
 de:
     title: SOLO-Theme-Bundle
-    description: >
-        SOLO ist ein Contao Theme für Agenturen, mit dem du eine professionelle Website für Solopreneure erstellen kannst. 
-        Es ist perfekt für Musiker:innen, Sportler:innen, Autor:innen, Coaches und viele weitere Einzelpersonen.
-        
-        SOLO basiert auf dem [Nutshell Framework](https://github.com/nutshell-framework) und wurde in Version 3 speziell für Contao 5.3 LTS entwickelt. 
-        Das Theme ist für alle gängigen Geräte (Smartphones, Tablets, Desktop) und Browser (Chrome, Firefox, MS Edge, Safari) optimiert.
-
-        Besonderheiten von SOLO sind unter anderem
-        
-        einfache Installation über den Contao Manager oder das Contao Backend, 
-        einfache Farbanpassungen über Custom Properties (CSS Variablen) vielseitige Anpassungsmöglichkeiten über SCSS, 
-        Gestaltung aller Standard-Inhaltselemente, Hero-Element mit Varianten für Schriftgröße und Schriftpositionierung,
-        keine Copyright- oder Backlink-Pflicht notwendig.
-        
-        SOLO nutzt die neuen verschachtelten Inhaltselemente für Akkordeon und Slider
-    keywords:
-        - SOLO
-        - Theme
-        - Template
-        - scss
-        - Layout
-        - Erdmann und Freunde
+    discoverable: false

--- a/meta/erdmannfreunde/solo-theme-bundle/en.yml
+++ b/meta/erdmannfreunde/solo-theme-bundle/en.yml
@@ -1,24 +1,3 @@
 en:
     title: SOLO theme bundle
-    description: >
-        SOLO is a Contao theme for agencies that allows you to create a professional website for solopreneurs. 
-        It is perfect for musicians, athletes, authors, coaches and many other individuals.
-        
-        SOLO is based on the [Nutshell Framework](https://github.com/nutshell-framework) and was developed in version 3 especially for Contao 5.3 LTS. 
-        The theme is optimized for all common devices (smartphones, tablets, desktop) and browsers (Chrome, Firefox, MS Edge, Safari).
-    
-        Special features of SOLO include 
-        
-        Easy installation via the Contao Manager or the Contao backend, 
-        simple color adjustments via custom properties (CSS variables) versatile customization options via SCSS, 
-        design of all standard content elements, hero element with variants for font size and positioning,
-        no copyright or backlink obligation necessary.
-        
-        SOLO uses the new nested content elements for accordion and slider
-    keywords:
-        - SOLO
-        - Theme
-        - Template
-        - scss
-        - Layout
-        - Erdmann und Freunde
+    discoverable: false


### PR DESCRIPTION
This lists the actual theme name instead of the required extension in the extension list, and will also cause it to show up in the theme search on installation.

@denniserdmann please approve to get this merged.