### PR TITLE
Set DC_Multilingual to discoverable: false

### DIFF
--- a/meta/terminal42/dc_multilingual/de.yml
+++ b/meta/terminal42/dc_multilingual/de.yml
@@ -8,4 +8,4 @@ de:
         - Navigation
         - SEO
         - Alias
-    dependency: true
+    discoverable: false

--- a/meta/terminal42/dc_multilingual/en.yml
+++ b/meta/terminal42/dc_multilingual/en.yml
@@ -9,4 +9,4 @@ en:
         - navigation
         - alias
         - seo
-    dependency: true
+    discoverable: false


### PR DESCRIPTION
There [are extensions](https://packagist.org/packages/terminal42/dc_multilingual/suggesters) who suggest to install `terminal42/dc_multilingual` for additional back end features. However, there was one such case recently where someone thus tried to simply enter "dc_multilingual" in the package search of the Contao Manager. This does not [yield the correct results](https://extensions.contao.org/?q=dc_multilingual) and the user installed an unnecessary package instead.

Similar to https://github.com/contao/package-metadata/pull/594 https://github.com/contao/package-metadata/pull/129 this package should also be discoverable via the search.