### PR TITLE
Use actions/cache@v4

### DIFF
--- a/.github/workflows/index-on-push.yaml
+++ b/.github/workflows/index-on-push.yaml
@@ -23,7 +23,7 @@ jobs:
                   fetch-depth: 2
 
             - name: Cache Composer Vendor
-              uses: actions/cache@v1
+              uses: actions/cache@v4
               with:
                   path: indexer/vendor/
                   key: ${{ runner.os }}-indexer-vendor-${{ hashFiles('indexer/composer.lock') }}

--- a/.github/workflows/index-rebuild.yml
+++ b/.github/workflows/index-rebuild.yml
@@ -21,7 +21,7 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Cache Composer Vendor
-              uses: actions/cache@v1
+              uses: actions/cache@v4
               with:
                   path: indexer/vendor/
                   key: ${{ runner.os }}-indexer-vendor-${{ hashFiles('indexer/composer.lock') }}

--- a/.github/workflows/index-scheduled.yaml
+++ b/.github/workflows/index-scheduled.yaml
@@ -18,7 +18,7 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Cache Composer Vendor
-              uses: actions/cache@v1
+              uses: actions/cache@v4
               with:
                   path: indexer/vendor/
                   key: ${{ runner.os }}-indexer-vendor-${{ hashFiles('indexer/composer.lock') }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,7 @@ jobs:
             - run: git fetch --prune --unshallow
 
             - name: Cache Composer vendor
-              uses: actions/cache@v1
+              uses: actions/cache@v4
               with:
                   path: linter/vendor/
                   key: ${{ runner.os }}-linter-vendor


### PR DESCRIPTION
`v1` and `v2` of `actions/cache` are deprecated respectively already removed.

https://github.com/actions/cache/blob/main/README.md#%EF%B8%8F-important-changes