### PR TITLE
Hide pdir dependencies

### DIFF
--- a/meta/pdir/contao-api-bundle/de.yml
+++ b/meta/pdir/contao-api-bundle/de.yml
@@ -10,3 +10,4 @@ de:
     homepage: https://pdir.de/
     support:
         email: support@pdir.de
+    dependency: true

--- a/meta/pdir/contao-api-bundle/en.yml
+++ b/meta/pdir/contao-api-bundle/en.yml
@@ -10,3 +10,4 @@ en:
     homepage: https://pdir.de/
     support:
         email: support@pdir.de
+    dependency: true

--- a/meta/pdir/helper-bundle/de.yml
+++ b/meta/pdir/helper-bundle/de.yml
@@ -8,3 +8,4 @@ de:
     homepage: https://pdir.de/
     support:
         email: support@pdir.de
+    dependency: true

--- a/meta/pdir/helper-bundle/en.yml
+++ b/meta/pdir/helper-bundle/en.yml
@@ -8,3 +8,4 @@ en:
     homepage: https://pdir.de/
     support:
         email: support@pdir.de
+    dependency: true


### PR DESCRIPTION
These recently showed up in my extension search, but both are not installable and look like the labels are only for when you have privately installed these packages. @MDevster can you confirm that?