### PR TITLE
Add KIWI logo

### DIFF
--- a/meta/kiwi/logo.svg
+++ b/meta/kiwi/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" x="0" y="0" style="enable-background:new 0 0 63.4 49.5" version="1.1" viewBox="0 0 63.4 49.5"><path d="M0 0h13.2v20.2h.1L28.2 0h15.9L25.8 23.1l19.7 26.5H28.7L13.3 27h-.1v22.5H0V0zM51.5 38h11.9v11.5H51.5V38z" fill="#000"/></svg>


### PR DESCRIPTION
We (KIWI. Werbeagentur GmbH) just published an extensive suite of layout bundles a few days ago, which we are going to present at the upcoming Contao conference 2025. Just wanted to add a logo for our vendor, so the bundles don't look so bleak when installing them (or having installed them).
---
Wir (KIWI. Werbeagentur GmbH) haben vor einigen Tagen eine umfangreiche Suite von Layout-Bundles veröffentlicht, welche wir auf der kommenden Contao-Konferenz 2025 vorstellen werden. Wir wollten nur noch ein Logo für unser Vendor-Kürzel hinterlegen, damit die Bundles nicht so unscheinbar aussehen, wenn man sie installiert (hat).