### PR TITLE
Add composer.json and homepage link for xliff extensions

### DIFF
--- a/meta/christianbargon/contao-i18n-duplication/composer.json
+++ b/meta/christianbargon/contao-i18n-duplication/composer.json
@@ -1,0 +1,29 @@
+{
+    "name": "christianbargon/contao-i18n-duplication",
+    "type": "contao-bundle",
+    "description": "Duplicate Content while Adjusting the References for Contao Open Source CMS",
+    "keywords": ["contao", "duplicate", "language"],
+    "homepage": "https://contao2xliff.de",
+    "license": "proprietary",
+    "authors": [
+        {
+            "name": "Christian Bargon Multimediadesign",
+            "homepage": "https://christianbargon.de",
+            "role": "Support and Sales"
+        },
+        {
+            "name": "terminal42 gmbh",
+            "homepage": "https://www.terminl42.ch",
+            "role": "Developer"
+        }
+    ],
+    "support": {
+        "email": "support@contao2xliff.de",
+        "docs": "https://contao2xliff.de"
+    },
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "ext-json": "*",
+        "contao/core-bundle": "^4.9 || ^5.0"
+    }
+}

--- a/meta/christianbargon/contao-i18n-duplication/de.yml
+++ b/meta/christianbargon/contao-i18n-duplication/de.yml
@@ -1,7 +1,7 @@
 de:
     title: Inhalte Duplizieren
-    description: > 
-        Contao-Inhalte mit einem Klick duplizieren. Insert-Tags, Weiterleitungsseiten und Hauptsprache (bei der Verwendung von ChangeLanguage) werden automatisch angepasst. Geeignet für Vorarbeiten zur Übersetzung der Internetseite mit z. B. Contao2xliff.   
+    description: >
+        Contao-Inhalte mit einem Klick duplizieren. Insert-Tags, Weiterleitungsseiten und Hauptsprache (bei der Verwendung von ChangeLanguage) werden automatisch angepasst. Geeignet für Vorarbeiten zur Übersetzung der Internetseite mit z. B. Contao2xliff.
     keywords:
         - Duplizieren
         - Inhalte
@@ -11,4 +11,4 @@ de:
         - Nachrichten
         - Formulare
         - ChangeLanguage
-    homepage: https://contao2xliff.de
+    homepage: https://www.contao2xliff.de/inhalte-duplizieren.html

--- a/meta/christianbargon/contao-i18n-duplication/en.yml
+++ b/meta/christianbargon/contao-i18n-duplication/en.yml
@@ -1,7 +1,7 @@
 en:
     title: Duplicate Content
-    description: > 
-        Duplicate Contao contents with just one click. Insert tags, forwarding pages, and main language (as used by ChangeLanguage) are adjusted automatically. Works perfectly for preparatory work to translate the website with, for example, Contao2xliff.  
+    description: >
+        Duplicate Contao contents with just one click. Insert tags, forwarding pages, and main language (as used by ChangeLanguage) are adjusted automatically. Works perfectly for preparatory work to translate the website with, for example, Contao2xliff.
     keywords:
         - duplicate
         - content
@@ -11,4 +11,4 @@ en:
         - news
         - forms
         - ChangeLanguage
-    homepage: https://contao2xliff.de
+    homepage: https://www.contao2xliff.de/inhalte-duplizieren.html

--- a/meta/christianbargon/contao-xliff-translations/composer.json
+++ b/meta/christianbargon/contao-xliff-translations/composer.json
@@ -1,0 +1,45 @@
+{
+    "name": "christianbargon/contao-xliff-translations",
+    "type": "contao-bundle",
+    "description": "Ex- and Import of XLIFF Translation Files for Contao Open Source CMS",
+    "keywords": ["contao", "xliff", "import", "export", "translation"],
+    "homepage": "https://contao2xliff.de",
+    "license": "proprietary",
+    "authors": [
+        {
+            "name": "Christian Bargon Multimediadesign",
+            "homepage": "https://christianbargon.de",
+            "role": "Support and Sales"
+        },
+        {
+            "name": "terminal42 gmbh",
+            "homepage": "https://www.terminl42.ch",
+            "role": "Developer"
+        }
+    ],
+    "support": {
+        "email": "support@contao2xliff.de",
+        "docs": "https://contao2xliff.de/dokumentation.html",
+        "issues": "https://contao2xliff.de/support.html"
+    },
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "ext-json": "*",
+        "ext-dom": "*",
+        "ext-libxml": "*",
+        "contao/core-bundle": "^4.9 || ^5.0"
+    },
+    "conflict": {
+        "madeyourday/contao-rocksolid-custom-elements": "<2.2 || >=3.0",
+        "alnv/catalog-manager": "<1.28 || >=2.0",
+        "alnv/catalog-manager-bundle": "<2.0 || >=3.0",
+        "terminal42/contao-changelanguage": "<3.2 || >=4.0",
+        "terminal42/notification_center": "<1.5 || >=3.0",
+        "terminal42/dc_multilingual": "<3.0 || >=5.0",
+        "wangaz/xliff-translations-bundle": "*",
+        "wangaz/xliff-translations-custom-elements-bundle": "*",
+        "wangaz/xliff-translations-catalog-manager-bundle": "*",
+        "wangaz/xliff-translations-dc-multilingual-bundle": "*",
+        "wangaz/xliff-translations-notification-center-bundle": "*"
+    }
+}


### PR DESCRIPTION
@christianbargon please approve. The `composer.json` will let the Contao Manager know which Contao versions are supported. I also updated the homepage link for `i18n-duplication` to the respective subpage. If you redo the website, please update the link here again 🙃 