### PR TITLE
Update metadata for heimseiten/contao-custom-backend-settings-bundle

### DIFF
--- a/meta/heimseiten/contao-custom-backend-settings-bundle/de.yml
+++ b/meta/heimseiten/contao-custom-backend-settings-bundle/de.yml
@@ -1,7 +1,16 @@
 de:
-    title: Custom Backend Settings (heimseiten.de)
+    title: Custom Backend Settings
     description: >
-        Praktische Backend-Erweiterungen für Contao 5: Komfort-Optionen pro Benutzer
-        (Erscheinungsbild), globale Funktionen (direkt veröffentlichen, echtes Kopieren
-        von News/Events …) und überschreibbare Frontend-Beschriftungen (Weiterlesen,
-        Pagination).
+        Praktische Backend-Erweiterungen für Contao 5 – das meiste pro Backend-Benutzer
+        einstellbar (Benutzer ▸ Benutzer bearbeiten), gruppiert in die Legenden Funktionen,
+        Verhalten und Erscheinungsbild.
+
+        Funktionen: Seiten, Artikel, News und Events beim Anlegen direkt veröffentlichen;
+        News und Events mit allen Details kopieren; Kopien ohne den Zusatz (Kopie).
+
+        Verhalten: Ein Klick auf eine Artikel-, Inhaltselement- oder Seiten-Zeile öffnet
+        direkt deren Inhalte bzw. Einstellungen; in einer noch leeren Liste wird das erste
+        Element automatisch eingefügt.
+
+        Dazu globale Einstellungen (System ▸ Einstellungen) sowie – je Seitenlayout –
+        überschreibbare Frontend-Beschriftungen (Weiterlesen, Pagination).

--- a/meta/heimseiten/contao-custom-backend-settings-bundle/en.yml
+++ b/meta/heimseiten/contao-custom-backend-settings-bundle/en.yml
@@ -1,6 +1,15 @@
 en:
-    title: Custom Backend Settings (heimseiten.de)
+    title: Custom Backend Settings
     description: >
-        Handy backend enhancements for Contao 5: per-user appearance options, global
-        functions (publish on create, real copying of news/events …) and overridable
-        front end labels (read more, pagination).
+        Handy backend enhancements for Contao 5 – mostly configurable per backend user
+        (User ▸ Edit user), grouped in the functions, behaviour and appearance legends.
+
+        Functions: publish pages, articles, news and events on create; copy news and
+        events with all their details; copies without the (copy) suffix.
+
+        Behaviour: clicking the row of an article, a content element or a page opens its
+        contents or settings directly; in an empty list the first element is inserted
+        automatically.
+
+        Plus a few global settings (System ▸ Settings) and, per page layout, overridable
+        front-end labels (read more, pagination).


### PR DESCRIPTION
Updates title and description for `heimseiten/contao-custom-backend-settings-bundle` (de + en).

- **Title:** drops the vendor suffix → `Custom Backend Settings`.
- **Description:** reworked to focus on the per-user backend options, grouped by the *functions*, *behaviour* and *appearance* legends (Benutzer ▸ Benutzer bearbeiten), with paragraphs.

Spell-check linter passes locally (aspell de/en).