### PR TITLE
Add heimseiten/contao-backup-bundle metadata

### DIFF
--- a/linter/allowlists/default.txt
+++ b/linter/allowlists/default.txt
@@ -112,6 +112,7 @@ Cron
 cronjobs
 Cross
 CSP
+CSRF
 CSS
 CSV
 Dalley

--- a/meta/heimseiten/contao-backup-bundle/de.yml
+++ b/meta/heimseiten/contao-backup-bundle/de.yml
@@ -1,0 +1,15 @@
+de:
+    title: Sicherung – Datenbank und Dateien
+    homepage: https://github.com/heimseiten/contao-backup-bundle
+    description: >
+        Fügt im Backend unter „System" den Punkt „Sicherung" hinzu und lädt die Datenbank
+        sowie alle relevanten Dateien und Ordner als ZIP herunter – einzeln oder zusammen.
+        Das Archiv wird direkt ausgeliefert (kein Zwischenspeicher, auch mehrere Gigabyte) und
+        zeigt in Chrome und Edge den Fortschritt an. Nur für Administratoren und gegen CSRF
+        abgesichert.
+    keywords:
+        - Sicherung
+        - Backup
+        - Datenbank
+        - Download
+        - ZIP

--- a/meta/heimseiten/contao-backup-bundle/en.yml
+++ b/meta/heimseiten/contao-backup-bundle/en.yml
@@ -1,0 +1,14 @@
+en:
+    title: Backup – database and files
+    homepage: https://github.com/heimseiten/contao-backup-bundle
+    description: >
+        Adds a "Backup" entry under "System" in the back end and downloads the database and
+        all relevant files and folders as a ZIP – separately or together. The archive is
+        streamed directly (no temporary storage, even several gigabytes) and shows a progress
+        bar in Chrome and Edge. Administrators only and protected against CSRF.
+    keywords:
+        - backup
+        - database
+        - download
+        - ZIP
+        - files

--- a/meta/heimseiten/contao-backup-bundle/logo.svg
+++ b/meta/heimseiten/contao-backup-bundle/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="96" fill="#f47c00"/>
+  <g fill="none" stroke="#ffffff" stroke-width="36" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M256 104 V300"/>
+    <path d="M178 230 L256 308 L334 230"/>
+    <path d="M382 300 V360 a30 30 0 0 1 -30 30 H160 a30 30 0 0 1 -30 -30 V300"/>
+  </g>
+</svg>


### PR DESCRIPTION
Adds Contao Manager metadata for `heimseiten/contao-backup-bundle`.

The package adds a "Sicherung" (Backup) page under **System** in the Contao back end that downloads the database backup and all relevant files/folders as a streamed ZIP – separately or together. Administrators only, CSRF-protected.

- `de.yml` / `en.yml` / `logo.svg`
- `homepage` set (the package is published on GitHub; Packagist registration follows)
- adds `CSRF` to the `default` allow list
