### PR TITLE
[heimseiten/contao-backup-bundle] Update title and description (backup + restore)

### DIFF
--- a/linter/allowlists/de.txt
+++ b/linter/allowlists/de.txt
@@ -334,6 +334,7 @@ Formularseiten
 Formularwidget
 Formvalidation
 formvalidation
+Fortschrittsanzeige
 Fremdschlüssel
 Frontend
 Frontendformular
@@ -360,6 +361,7 @@ gerendert
 gescannten
 Geschäftsabläufe
 Geschütztes
+gestreamt
 gestylt
 gestylten
 Get

--- a/linter/allowlists/default.txt
+++ b/linter/allowlists/default.txt
@@ -34,6 +34,7 @@ AWS
 Back end
 back end
 Backend
+backups
 barcode
 Barcode
 Bard

--- a/meta/heimseiten/contao-backup-bundle/de.yml
+++ b/meta/heimseiten/contao-backup-bundle/de.yml
@@ -1,15 +1,15 @@
 de:
-    title: Sicherung – Datenbank und Dateien
+    title: Sicherung und Wiederherstellung
     homepage: https://github.com/heimseiten/contao-backup-bundle
     description: >
-        Fügt im Backend unter „System" den Punkt „Sicherung" hinzu und lädt die Datenbank
-        sowie alle relevanten Dateien und Ordner als ZIP herunter – einzeln oder zusammen.
-        Das Archiv wird direkt ausgeliefert (kein Zwischenspeicher, auch mehrere Gigabyte) und
-        zeigt in Chrome und Edge den Fortschritt an. Nur für Administratoren und gegen CSRF
-        abgesichert.
+        Fügt im Backend unter „System" den Punkt „Sicherung" hinzu: Datenbank und alle
+        relevanten Dateien als ZIP herunterladen (gestreamt, auch mehrere Gigabyte, mit
+        Fortschrittsanzeige) und Backups wiederherstellen – aus var/backups oder per Upload
+        eines Archivs, auch in eine andere Installation. Nur für Administratoren und gegen
+        CSRF abgesichert.
     keywords:
         - Sicherung
+        - Wiederherstellung
         - Backup
         - Datenbank
-        - Download
         - ZIP

--- a/meta/heimseiten/contao-backup-bundle/en.yml
+++ b/meta/heimseiten/contao-backup-bundle/en.yml
@@ -1,14 +1,14 @@
 en:
-    title: Backup – database and files
+    title: Backup and Restore
     homepage: https://github.com/heimseiten/contao-backup-bundle
     description: >
-        Adds a "Backup" entry under "System" in the back end and downloads the database and
-        all relevant files and folders as a ZIP – separately or together. The archive is
-        streamed directly (no temporary storage, even several gigabytes) and shows a progress
-        bar in Chrome and Edge. Administrators only and protected against CSRF.
+        Adds a "Backup" entry under "System" in the back end: download the database and all
+        relevant files as a ZIP (streamed, even several gigabytes, with a progress bar) and
+        restore backups – from var/backups or by uploading an archive, also into another
+        installation. Administrators only and protected against CSRF.
     keywords:
         - backup
+        - restore
         - database
         - download
         - ZIP
-        - files


### PR DESCRIPTION
Updates the title and description of `heimseiten/contao-backup-bundle`.

Since version 1.1 the extension can not only download backups but also **restore** them (from `var/backups` or by uploading an archive, also into another installation). The metadata now reflects that:

- **Title:** „Sicherung und Wiederherstellung" / "Backup and Restore" (was: „Sicherung – Datenbank und Dateien" / "Backup – database and files")
- **Description:** extended to mention the restore feature.
- Three legitimate words added to the spell-check allow list (`gestreamt`, `Fortschrittsanzeige`, `backups`).

The linter passes locally for both changed files.