### PR TITLE
Add Theme Ultimate Visitor Statistics metadata

### DIFF
--- a/linter/allowlists/de.txt
+++ b/linter/allowlists/de.txt
@@ -868,6 +868,7 @@ Standortermittlung
 Startbildschirm
 Startups
 Startzeit
+Statistics
 Statistikübersicht
 Stellenanzeigen
 Sternzeit
@@ -1002,6 +1003,7 @@ Videohandbuch
 Viewer
 Visibility
 visibility
+Visitor
 visits
 Visualization
 visuell

--- a/meta/theme-ultimate/installer-theme-ultimate-visitor-statistics/de.yml
+++ b/meta/theme-ultimate/installer-theme-ultimate-visitor-statistics/de.yml
@@ -1,7 +1,7 @@
 de:
     title: Theme Ultimate Visitor Statistics
     description: >
-        Installiert die lokale Besucherstatistik aus dem privaten Theme-Ultimate-Paketarchiv.
+        Installiert die lokale Statistik für Besucher aus dem privaten Theme-Ultimate-Paketarchiv.
         Erfordert vorab das Zugangspaket für den Archivzugriff.
     homepage: https://www.theme-ultimate.de
     keywords:

--- a/meta/theme-ultimate/installer-theme-ultimate-visitor-statistics/de.yml
+++ b/meta/theme-ultimate/installer-theme-ultimate-visitor-statistics/de.yml
@@ -1,0 +1,12 @@
+de:
+    title: Theme Ultimate Visitor Statistics
+    description: >
+        Installiert die lokale Besucherstatistik aus dem privaten Theme-Ultimate-Paketarchiv.
+        Erfordert vorab das Zugangspaket für den Archivzugriff.
+    homepage: https://www.theme-ultimate.de
+    keywords:
+        - Theme Ultimate
+        - Contao
+        - Installer
+        - Besucherstatistik
+        - Analytics

--- a/meta/theme-ultimate/installer-theme-ultimate-visitor-statistics/en.yml
+++ b/meta/theme-ultimate/installer-theme-ultimate-visitor-statistics/en.yml
@@ -1,0 +1,12 @@
+en:
+    title: Theme Ultimate Visitor Statistics
+    description: >
+        Installs the local visitor statistics extension from the private Theme Ultimate repository.
+        Requires the package theme-ultimate/repository-license first.
+    homepage: https://www.theme-ultimate.de
+    keywords:
+        - Theme Ultimate
+        - Contao
+        - Installer
+        - Visitor statistics
+        - Analytics

--- a/meta/theme-ultimate/theme-ultimate-visitor-statistics/de.yml
+++ b/meta/theme-ultimate/theme-ultimate-visitor-statistics/de.yml
@@ -1,7 +1,7 @@
 de:
     title: Theme Ultimate Visitor Statistics
     description: >
-        Erfasst und analysiert Besuche, Seitenaufrufe, Herkunft, Browser, Geräte und Robots
+        Erfasst und analysiert Besuche, Seitenaufrufe, Herkunft, Browser, Geräte und Bots
         ausschließlich lokal in Contao 5.7.
     dependency: true
     discoverable: false

--- a/meta/theme-ultimate/theme-ultimate-visitor-statistics/de.yml
+++ b/meta/theme-ultimate/theme-ultimate-visitor-statistics/de.yml
@@ -1,0 +1,14 @@
+de:
+    title: Theme Ultimate Visitor Statistics
+    description: >
+        Erfasst und analysiert Besuche, Seitenaufrufe, Herkunft, Browser, Geräte und Robots
+        ausschließlich lokal in Contao 5.7.
+    dependency: true
+    discoverable: false
+    homepage: https://www.theme-ultimate.de
+    keywords:
+        - Theme Ultimate
+        - Contao
+        - Besucherstatistik
+        - Analytics
+        - Datenschutz

--- a/meta/theme-ultimate/theme-ultimate-visitor-statistics/en.yml
+++ b/meta/theme-ultimate/theme-ultimate-visitor-statistics/en.yml
@@ -1,0 +1,14 @@
+en:
+    title: Theme Ultimate Visitor Statistics
+    description: >
+        Records and analyzes visits, page views, origin, browsers, devices and robots
+        exclusively locally in Contao 5.7.
+    dependency: true
+    discoverable: false
+    homepage: https://www.theme-ultimate.de
+    keywords:
+        - Theme Ultimate
+        - Contao
+        - Visitor statistics
+        - Analytics
+        - Privacy


### PR DESCRIPTION
## Summary
- add localized Contao Manager metadata for the public installer
- keep the private implementation package hidden and dependency-only

## Testing
- official metadata linter passed for all four files with the spell check skipped locally because Aspell is unavailable
- YAML, UTF-8, line endings and schema fields were validated
- the installer is published on Packagist as version 1.0.0