### PR TITLE
Add metadata for schachbulle/contao-digiviewer-bundle

### DIFF
--- a/linter/allowlists/de.txt
+++ b/linter/allowlists/de.txt
@@ -113,14 +113,18 @@ Bildformaten
 Bildgröße
 Bildgrößen
 Bildgrößeneinstellung
+Bildinhalte
 Bildpipeline
 Bildreferenzen
+Bildsammlung
+Bildsammlungen
 Bildschirmpräsentation
 Bildslider
 Bildvergleich
 Bildvorschau
 bits
 bla
+Blätterfunktion
 Blätterkataloge
 Body
 body
@@ -237,6 +241,7 @@ Drittstaatentransfer
 Drop
 Dropdown
 Duplication
+durchsuchbar
 easyRechtssicher
 EasyRechtssicher
 EasyThemes
@@ -250,6 +255,7 @@ Eingabeattribut
 Eingabeformulare
 Eingabeprüfung
 Eingabevalidierung
+eingescannte
 Einrichtungsassistent
 Einstellungsmöglichkeiten
 Einstiegspunkte
@@ -769,6 +775,7 @@ Root
 Routenplaner
 Routenplanung
 Röntgenaufnahmen
+Scans
 Schachbund
 Schachbundes
 Schachturnier
@@ -891,6 +898,7 @@ Suchergebnisse
 Suchergebnissen
 Suchfunktion
 Suchindex
+Suchmaschinen
 Suchmoduls
 Suchserver
 Suchsystemen

--- a/linter/allowlists/de.txt
+++ b/linter/allowlists/de.txt
@@ -1021,6 +1021,7 @@ Vollbildmodus
 Volltextsuche
 Vorlagedatei
 Vorschaubild
+Vorschauleiste
 Wallets
 Warenkorbfunktionen
 Warenkorbregeln

--- a/linter/allowlists/default.txt
+++ b/linter/allowlists/default.txt
@@ -60,6 +60,7 @@ branch
 Branches
 branches
 Breadcrumb
+Breitbart
 BROCKHAUS
 Buchholz
 Bulma
@@ -136,6 +137,7 @@ DHL
 DICOM
 Digistore
 Digistore24
+DigiViewer
 DMS
 DOC
 DOCX
@@ -271,6 +273,7 @@ IT
 iTunes
 JavaScript
 JIS
+Joerg
 JointForms
 JPEG
 jpg

--- a/meta/schachbulle/contao-digiviewer-bundle/de.yml
+++ b/meta/schachbulle/contao-digiviewer-bundle/de.yml
@@ -1,0 +1,16 @@
+de:
+    title: DigiViewer
+    description: >
+        Digitaler Betrachter für Bildsammlungen mit Blätterfunktion, Zoom und Vorschauleiste — etwa für eingescannte Zeitschriften, Chroniken oder Urkunden.
+
+        Hinterlegte OCR-Texte machen die Bildinhalte für die Contao-Suche und für Suchmaschinen durchsuchbar.
+
+        Als Anzeige-Engine dient der DigiViewer von Joerg Breitbart.
+    keywords:
+        - Bilder
+        - Bildsammlung
+        - Viewer
+        - Scans
+    support:
+        issues: https://github.com/Samson1964/contao-digiviewer-bundle/issues
+        source: https://github.com/Samson1964/contao-digiviewer-bundle

--- a/meta/schachbulle/contao-digiviewer-bundle/en.yml
+++ b/meta/schachbulle/contao-digiviewer-bundle/en.yml
@@ -1,0 +1,16 @@
+en:
+    title: DigiViewer
+    description: >
+        Digital viewer for image collections with page navigation, zoom and a thumbnail sidebar — for scanned magazines, chronicles or certificates.
+
+        Stored OCR texts make the image contents searchable for the Contao search and for search engines.
+
+        The display engine is the DigiViewer by Joerg Breitbart.
+    keywords:
+        - images
+        - image collection
+        - viewer
+        - scans
+    support:
+        issues: https://github.com/Samson1964/contao-digiviewer-bundle/issues
+        source: https://github.com/Samson1964/contao-digiviewer-bundle


### PR DESCRIPTION
Adds German and English metadata for [schachbulle/contao-digiviewer-bundle](https://packagist.org/packages/schachbulle/contao-digiviewer-bundle), a digital viewer for image collections (scanned magazines, chronicles, certificates) with page navigation, zoom and a thumbnail sidebar.

The new German compound nouns and proper names used in the descriptions were added to the spell checker allow lists (`de.txt` and `default.txt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)