### PR TITLE
Add metadata for schachbulle/contao-grandprix-bundle

### DIFF
--- a/linter/allowlists/de.txt
+++ b/linter/allowlists/de.txt
@@ -128,6 +128,7 @@ Blätterfunktion
 Blätterkataloge
 Body
 body
+Bonuspunkten
 Bootstrapper
 Bordmittel
 Bots
@@ -264,6 +265,7 @@ Einwilligungsdaten
 Einwilligungseinstellungen
 Einwilligungsfunktion
 Einzelbestellungen
+Einzelturniere
 Elementsets
 Elternelement
 Elterntabelle
@@ -370,6 +372,7 @@ Geokodierungsdienste
 Geokoordinaten
 georeferenzierte
 gerendert
+Gesamtstand
 gescannten
 Geschäftsabläufe
 Geschütztes
@@ -724,6 +727,7 @@ Properties
 Protocol
 Pull
 Pulse
+Punktgleichheit
 Push
 PWA
 Pwned
@@ -787,6 +791,7 @@ Scheduler
 Schieberegler
 Schiebereglers
 Schlüsselverwaltung
+Schnellschach
 Schreibrechte
 Schriftpositionierung
 SCR
@@ -1019,6 +1024,7 @@ Vollbild
 Vollbildkarte
 Vollbildmodus
 Volltextsuche
+Vorjahressieger
 Vorlagedatei
 Vorschaubild
 Vorschauleiste
@@ -1039,6 +1045,7 @@ Weiterleitungsseite
 Weiterleitungsseiten
 Weiterleitungszielen
 Weiterlesen
+Wertungspunkten
 Wertungszahl
 Widerrufsbelehrung
 Wiederherstellungsfunktion

--- a/linter/allowlists/default.txt
+++ b/linter/allowlists/default.txt
@@ -229,6 +229,7 @@ Google
 googlemaps
 GPT
 GPX
+Grand
 Graphhopper
 grid
 gtag
@@ -420,6 +421,7 @@ POIs
 PostFinance
 Preload
 preload
+Prix
 Prod
 prod
 Prompts

--- a/meta/schachbulle/contao-grandprix-bundle/de.yml
+++ b/meta/schachbulle/contao-grandprix-bundle/de.yml
@@ -1,0 +1,15 @@
+de:
+    title: Berliner Schnellschach-Grand-Prix
+    description: >
+        Berechnet den Gesamtstand einer Grand-Prix-Serie aus den CSV-Tabellen der Einzelturniere und stellt ihn im Frontend dar.
+
+        Mit Wertungspunkten je Platz, Begrenzung auf die besten x Turniere, Feinwertungen bei Punktgleichheit und Bonuspunkten für den Vorjahressieger.
+    keywords:
+        - Schach
+        - Schnellschach
+        - Grand-Prix
+        - Wertung
+        - Turnier
+    support:
+        issues: https://github.com/Samson1964/contao-grandprix-bundle/issues
+        source: https://github.com/Samson1964/contao-grandprix-bundle

--- a/meta/schachbulle/contao-grandprix-bundle/de.yml
+++ b/meta/schachbulle/contao-grandprix-bundle/de.yml
@@ -5,6 +5,7 @@ de:
 
         Mit Wertungspunkten je Platz, Begrenzung auf die besten x Turniere, Feinwertungen bei Punktgleichheit und Bonuspunkten für den Vorjahressieger.
     keywords:
+        - Berlin
         - Schach
         - Schnellschach
         - Grand-Prix

--- a/meta/schachbulle/contao-grandprix-bundle/en.yml
+++ b/meta/schachbulle/contao-grandprix-bundle/en.yml
@@ -5,6 +5,7 @@ en:
 
         With rating points per place, a limit to the best x tournaments, tie-breaks on equal points and bonus points for the previous year's winner.
     keywords:
+        - Berlin
         - chess
         - rapid chess
         - grand prix

--- a/meta/schachbulle/contao-grandprix-bundle/en.yml
+++ b/meta/schachbulle/contao-grandprix-bundle/en.yml
@@ -1,0 +1,15 @@
+en:
+    title: Berlin Rapid Chess Grand Prix
+    description: >
+        Calculates the overall standings of a grand prix series from the CSV tables of the individual tournaments and displays them in the front end.
+
+        With rating points per place, a limit to the best x tournaments, tie-breaks on equal points and bonus points for the previous year's winner.
+    keywords:
+        - chess
+        - rapid chess
+        - grand prix
+        - rating
+        - tournament
+    support:
+        issues: https://github.com/Samson1964/contao-grandprix-bundle/issues
+        source: https://github.com/Samson1964/contao-grandprix-bundle

--- a/meta/schachbulle/contao-grandprix-bundle/en.yml
+++ b/meta/schachbulle/contao-grandprix-bundle/en.yml
@@ -1,7 +1,7 @@
 en:
     title: Berlin Rapid Chess Grand Prix
     description: >
-        Calculates the overall standings of a grand prix series from the CSV tables of the individual tournaments and displays them in the front end.
+        Calculates the overall standings of a Grand Prix series from the CSV tables of the individual tournaments and displays them in the front end.
 
         With rating points per place, a limit to the best x tournaments, tie-breaks on equal points and bonus points for the previous year's winner.
     keywords:


### PR DESCRIPTION
Adds German and English metadata for [schachbulle/contao-grandprix-bundle](https://packagist.org/packages/schachbulle/contao-grandprix-bundle), which calculates the overall standings of a rapid chess grand prix series from the CSV tables of the individual tournaments and displays them in the front end.

The new German compound nouns and proper names used in the descriptions were added to the spell checker allow lists (`de.txt` and `default.txt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)