### PR TITLE
Add metadata for schachbulle/contao-boxes4ward-bundle

### DIFF
--- a/meta/schachbulle/contao-boxes4ward-bundle/de.yml
+++ b/meta/schachbulle/contao-boxes4ward-bundle/de.yml
@@ -12,5 +12,4 @@ de:
         - Seitenleiste
         - Nachrichten
     support:
-        issues: https://github.com/Samson1964/contao-boxes4ward-bundle/issues
         source: https://github.com/Samson1964/contao-boxes4ward-bundle

--- a/meta/schachbulle/contao-boxes4ward-bundle/de.yml
+++ b/meta/schachbulle/contao-boxes4ward-bundle/de.yml
@@ -1,0 +1,16 @@
+de:
+    title: Inhaltsboxen
+    description: >
+        Verwaltet Inhalte in Inhaltsboxen, die unabhängig von den Artikeln einer einzelnen Seite gepflegt werden — etwa ein Hinweis in der Seitenleiste.
+
+        Jede Box legt selbst fest, wo und wann sie erscheint: auf ausgewählten Seiten samt Unterseiten, nur an bestimmten Wochentagen oder in bestimmten Monaten, oder nur bei bestimmten Nachrichten.
+
+        Ausgegeben werden die Boxen von einem Frontend-Modul im Seitenlayout. Die Rechte im Backend werden je Kategorie vergeben.
+    keywords:
+        - Boxen
+        - Inhaltsboxen
+        - Seitenleiste
+        - Nachrichten
+    support:
+        issues: https://github.com/Samson1964/contao-boxes4ward-bundle/issues
+        source: https://github.com/Samson1964/contao-boxes4ward-bundle

--- a/meta/schachbulle/contao-boxes4ward-bundle/en.yml
+++ b/meta/schachbulle/contao-boxes4ward-bundle/en.yml
@@ -12,5 +12,4 @@ en:
         - sidebar
         - news
     support:
-        issues: https://github.com/Samson1964/contao-boxes4ward-bundle/issues
         source: https://github.com/Samson1964/contao-boxes4ward-bundle

--- a/meta/schachbulle/contao-boxes4ward-bundle/en.yml
+++ b/meta/schachbulle/contao-boxes4ward-bundle/en.yml
@@ -1,0 +1,16 @@
+en:
+    title: Content boxes
+    description: >
+        Manages content in boxes that are maintained independently of the articles of a single page — a note in the sidebar, for example.
+
+        Each box decides where and when it appears: on selected pages including their subpages, on certain weekdays or in certain months, or only for certain news items.
+
+        The boxes are rendered by a front end module in the page layout. Back end permissions are granted per category.
+    keywords:
+        - boxes
+        - content boxes
+        - sidebar
+        - news
+    support:
+        issues: https://github.com/Samson1964/contao-boxes4ward-bundle/issues
+        source: https://github.com/Samson1964/contao-boxes4ward-bundle


### PR DESCRIPTION
Adds the German and English metadata for [`schachbulle/contao-boxes4ward-bundle`](https://packagist.org/packages/schachbulle/contao-boxes4ward-bundle).

The extension manages content in boxes that are maintained independently of the articles of a single page. Each box carries its own display rules — selected pages including their subpages, weekdays, months, or individual news items — and is rendered by a front end module placed in the page layout.

It is a port of the Contao 3 extension `psi/boxes4ward` to Contao 4.13 and 5.7.

No allow list changes are needed: every unusual word in the descriptions is either already allow-listed or in use in existing metadata files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)