### PR TITLE
Add keywords for contao-multimarker-map

### DIFF
--- a/meta/datashop/contao-multimarker-map/de.yml
+++ b/meta/datashop/contao-multimarker-map/de.yml
@@ -4,6 +4,16 @@ de:
         Contao-Content-Element für eine interaktive Karte mit mehreren Markern - wahlweise mit OpenStreetMap (Leaflet) oder Google Maps, bei identischer Markerverwaltung im Backend.
 
         Jeder Marker erhält Titel, Position und einen frei gestaltbaren Tooltip-Text sowie automatisch einen Routing-Link, der auf Mobilgeräten die installierte Maps-App und auf dem Desktop die Maps-Website öffnet. Kartenfarbe (inkl. Graustufen-Modus), Markerfarbe, Zoomstufe und weitere Darstellungsoptionen sind im Backend konfigurierbar.
+    keywords:
+        - map
+        - maps
+        - karte
+        - marker
+        - multimarker
+        - openstreetmap
+        - leaflet
+        - google maps
+        - routing
     support:
         issues: https://github.com/datashop-cc/contao-multimarker-map/issues
         docs: https://github.com/datashop-cc/contao-multimarker-map#readme

--- a/meta/datashop/contao-multimarker-map/en.yml
+++ b/meta/datashop/contao-multimarker-map/en.yml
@@ -4,6 +4,16 @@ en:
         Contao content element for an interactive map with multiple markers - using either OpenStreetMap (Leaflet) or Google Maps, with identical marker management in the backend.
 
         Each marker has a title, position and a freely editable tooltip text, plus an automatic routing link that opens the installed maps app on mobile devices and the maps website on desktop. Map color (including a grayscale mode), marker color, zoom level and further display options are configurable in the backend.
+    keywords:
+        - map
+        - maps
+        - karte
+        - marker
+        - multimarker
+        - openstreetmap
+        - leaflet
+        - google maps
+        - routing
     support:
         issues: https://github.com/datashop-cc/contao-multimarker-map/issues
         docs: https://github.com/datashop-cc/contao-multimarker-map#readme


### PR DESCRIPTION
Adds keywords to the German and English metadata for datashop/contao-multimarker-map.

The package metadata already contains the title "Multimarker Map", but the title is currently not displayed in the Contao Manager. Instead, the package name is shown.

I could not find a difference in the title configuration compared to datashop/contao-cookiebar-bridge, where the title is displayed correctly. Could you please check if anything else is required for the title to be picked up by the Contao Manager?