### PR TITLE
Add netzhirsch/contao-mcp-bundle

### DIFF
--- a/linter/allowlists/default.txt
+++ b/linter/allowlists/default.txt
@@ -107,6 +107,7 @@ Contao
 ContaoDMS
 ContaoMonitoring
 contents
+Context
 CONVERT
 COPPA
 Corona

--- a/linter/allowlists/default.txt
+++ b/linter/allowlists/default.txt
@@ -339,6 +339,7 @@ mar-ke
 master
 Matomo
 MaxMind
+MCP
 MCW
 Meilisearch
 MetaModel

--- a/meta/netzhirsch/contao-mcp-bundle/de.yml
+++ b/meta/netzhirsch/contao-mcp-bundle/de.yml
@@ -12,8 +12,7 @@ de:
         der bestehenden Contao-Installation. Ein eigener Dienst oder ein zusätzlicher Port sind nicht nötig.
 
         Kommerzielle Erweiterung: 30 Tage kostenlos testen, danach 49 € pro Monat und Contao-Installation.
-        Testphase und Abonnement werden im Contao-Backend gestartet, die Zahlung läuft über gesicherte
-        Stripe-Seiten.
+        Gestartet wird beides direkt im Contao-Backend, die Zahlung läuft über gesicherte Stripe-Seiten.
     keywords:
         - MCP
         - Claude

--- a/meta/netzhirsch/contao-mcp-bundle/de.yml
+++ b/meta/netzhirsch/contao-mcp-bundle/de.yml
@@ -1,0 +1,26 @@
+de:
+    title: Contao MCP Bundle
+    homepage: https://www.netzhirsch.de/contao-mcp.html
+    description: >
+        Verbindet Claude und andere KI-Assistenten über das Model Context Protocol (MCP) mit dem Contao-Backend.
+        Statt für jede Aufgabe eine eigene Schnittstelle zu bauen, arbeitet die KI direkt mit der Website:
+        Seiten, Artikel, News, Termine, Mitglieder, Formulare, Newsletter, Kommentare, Themes, Templates und
+        Dateien. Rund 170 Werkzeuge stehen bereit, von der einzelnen Meldung bis zur kompletten Seitenstruktur.
+
+        Jeder Aufruf läuft mit den Rechten des Backend-Benutzers, der ihn autorisiert hat. Über die KI lässt
+        sich also nie mehr ändern als von Hand. Der Zugriff ist mit OAuth 2.1 abgesichert, der Server läuft in
+        der bestehenden Contao-Installation. Ein eigener Dienst oder ein zusätzlicher Port sind nicht nötig.
+
+        Kommerzielle Erweiterung: 30 Tage kostenlos testen, danach 49 € pro Monat und Contao-Installation.
+        Testphase und Abonnement werden im Contao-Backend gestartet, die Zahlung läuft über gesicherte
+        Stripe-Seiten.
+    keywords:
+        - MCP
+        - Claude
+        - KI
+        - Automatisierung
+        - OAuth
+    support:
+        issues: https://github.com/Netzhirsch/contao-mcp-bundle/issues
+        source: https://github.com/Netzhirsch/contao-mcp-bundle/releases
+        docs: https://www.netzhirsch.de/contao-mcp.html

--- a/meta/netzhirsch/contao-mcp-bundle/en.yml
+++ b/meta/netzhirsch/contao-mcp-bundle/en.yml
@@ -1,0 +1,25 @@
+en:
+    title: Contao MCP Bundle
+    homepage: https://www.netzhirsch.de/contao-mcp.html
+    description: >
+        Connects Claude and other AI assistants to the Contao backend through the Model Context Protocol (MCP).
+        Instead of building a separate interface for every task, the AI works with the site directly: pages,
+        articles, news, events, members, forms, newsletters, comments, themes, templates and files. Around 170
+        tools are available, from creating a single news entry to building a complete page structure.
+
+        Every call runs with the permissions of the backend user who authorised it, so an editor can never
+        change more through the AI than by hand. Access is protected with OAuth 2.1, and the server runs inside
+        the existing Contao installation. No separate service and no additional port are required.
+
+        Commercial extension: free for 30 days, afterwards 49 € per month and Contao installation. The trial and
+        the subscription are started in the Contao backend; payment is handled on secure Stripe pages.
+    keywords:
+        - MCP
+        - Claude
+        - AI
+        - automation
+        - OAuth
+    support:
+        issues: https://github.com/Netzhirsch/contao-mcp-bundle/issues
+        source: https://github.com/Netzhirsch/contao-mcp-bundle/releases
+        docs: https://www.netzhirsch.de/contao-mcp.html


### PR DESCRIPTION
Adds metadata for **netzhirsch/contao-mcp-bundle** (English + German).

The bundle turns a Contao installation into a [Model Context Protocol](https://modelcontextprotocol.io/) server, so Claude and other AI assistants can work with the site directly (pages, articles, news, events, members, forms, newsletters, comments, themes, templates, files). Calls run with the permissions of the back end user that authorised them, and access is protected with OAuth 2.1.

- Package on Packagist: https://packagist.org/packages/netzhirsch/contao-mcp-bundle
- Source: https://github.com/Netzhirsch/contao-mcp-bundle
- Product page: https://www.netzhirsch.de/contao-mcp.html

It is a commercial extension (30-day trial, then a subscription per Contao installation); this is stated in both descriptions so users know before installing.

`MCP` was added to `linter/allowlists/default.txt` — it is the product name and appears in both translations. The existing vendor logo at `meta/netzhirsch/logo.svg` is reused, so no package logo is included.