### PR TITLE
Add metadata for netzhirsch/contao-ai-tag-bundle

### DIFF
--- a/meta/netzhirsch/contao-ai-tag-bundle/de.yml
+++ b/meta/netzhirsch/contao-ai-tag-bundle/de.yml
@@ -1,0 +1,32 @@
+de:
+    title: Contao AI Tag Bundle
+    homepage: https://github.com/Netzhirsch/contao-ai-tag-bundle
+    description: >
+        Kennzeichnet KI-generierte Bilder in Contao so, dass die Kennzeichnung jede erzeugte Bildgröße
+        überlebt. Die Redaktion markiert eine Datei oder einen ganzen Ordner in der Dateiverwaltung, das
+        Bundle brennt den Hinweis beim Erzeugen jeder Bildgröße ein: am Rand des Bildes, möglichst außerhalb
+        des wichtigen Bereichs, mit automatisch passendem Kontrast und im Wortlaut der jeweiligen Sprache
+        der Website. Zusätzlich steht der Hinweis im alternativen Text des Bildes, weil eingebrannte Pixel
+        nicht vorgelesen werden.
+
+        Automatisch gekennzeichnet wird nichts. Artikel 50 der KI-Verordnung der EU verlangt die
+        Kennzeichnung nicht für jedes Bild, und diese Entscheidung trifft der Betreiber. Das Bundle
+        kennzeichnet deshalb nur, was die Redaktion markiert hat. Wer das darf, steuert ein eigenes Recht.
+        Ein Protokoll unter System hält fest, wer wann welche Datei markiert hat, und lässt sich als CSV
+        ausgeben, auf Wunsch ohne Namen.
+
+        Kommerzielle Erweiterung: Eine Lizenz braucht allein das Einbrennen in die Bilder. Markieren,
+        Protokoll, Export und der Hinweis im alternativen Text funktionieren dauerhaft ohne Lizenz, denn der
+        Zugriff auf die eigenen Nachweise darf nicht an einem Abonnement hängen. Zuerst kostenlos testen,
+        danach abonnieren: beides wird im Contao-Backend gestartet, bezahlt wird auf den gesicherten Seiten
+        von Stripe.
+    keywords:
+        - KI
+        - AI Act
+        - Kennzeichnung
+        - Bilder
+        - Barrierefreiheit
+    support:
+        issues: https://github.com/Netzhirsch/contao-ai-tag-bundle/issues
+        source: https://github.com/Netzhirsch/contao-ai-tag-bundle
+        docs: https://github.com/Netzhirsch/contao-ai-tag-bundle#readme

--- a/meta/netzhirsch/contao-ai-tag-bundle/en.yml
+++ b/meta/netzhirsch/contao-ai-tag-bundle/en.yml
@@ -1,0 +1,29 @@
+en:
+    title: Contao AI Tag Bundle
+    homepage: https://github.com/Netzhirsch/contao-ai-tag-bundle
+    description: >
+        Marks AI generated images in Contao so that the notice survives every image size Contao creates. An
+        editor marks a file or a whole folder in the file manager, and the bundle burns the notice into every
+        image size: at the edge of the image, outside the important part where possible, with automatic
+        contrast and in the language of the website. The notice is also added to the alternative text of the
+        image, because pixels are not read out by a screen reader.
+
+        Nothing is marked automatically. Article 50 of the EU AI Act does not ask for a notice on every
+        image, and that decision belongs to the operator, so the bundle only marks what an editor has
+        selected. A dedicated permission controls who may do that, and a log under System records who marked
+        which file and when. The log can be exported as CSV, on request without user names.
+
+        Commercial extension: a licence is needed for burning the notice into the images. Marking, the log,
+        the export and the notice in the alternative text keep working without a licence, because access to
+        your own records must not depend on a subscription. Test it for free first, then subscribe: both are
+        started in the Contao backend, and payment is handled on the secure pages of Stripe.
+    keywords:
+        - AI
+        - AI Act
+        - labelling
+        - images
+        - compliance
+    support:
+        issues: https://github.com/Netzhirsch/contao-ai-tag-bundle/issues
+        source: https://github.com/Netzhirsch/contao-ai-tag-bundle
+        docs: https://github.com/Netzhirsch/contao-ai-tag-bundle#readme


### PR DESCRIPTION
Metadata for [netzhirsch/contao-ai-tag-bundle](https://packagist.org/packages/netzhirsch/contao-ai-tag-bundle), a Contao 5.3+ bundle that burns an "AI generated" notice into every image size Contao creates (Art. 50 EU AI Act) and keeps a record of who marked which file.

* German and English metadata.
* No `logo.svg`: the vendor logo at `meta/netzhirsch/logo.svg` is used as the fallback.
* No allow list changes were necessary.

Linter run locally on Linux with `aspell`, `aspell-de` and `aspell-en` (`php linter/lint meta/netzhirsch/contao-ai-tag-bundle/de.yml meta/netzhirsch/contao-ai-tag-bundle/en.yml`): all checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
