### PR TITLE
Add schachbulle/contao-timeline-bundle metadata

### DIFF
--- a/meta/schachbulle/contao-timeline-bundle/de.yml
+++ b/meta/schachbulle/contao-timeline-bundle/de.yml
@@ -1,0 +1,15 @@
+de:
+    title: Zeitstrahl
+    description: >
+        Stellt geschichtliche Abläufe als Zeitstrahl dar. Der Besucher bewegt sich über eine Leiste am unteren Rand durch die einzelnen Stationen.
+
+        Jede Station trägt eine Überschrift, einen Text und wahlweise ein Bild, ein Video oder ein Zitat. Als Datum genügt eine Jahreszahl; ebenso möglich sind Angaben bis auf die Sekunde, Zeiträume und eine frei gewählte Beschriftung anstelle des Datums. Ganze Epochen fassen mehrere Stationen unter einem Balken zusammen.
+
+        Ausgegeben wird der Zeitstrahl als Inhaltselement oder als Frontendmodul im Seitenlayout.
+    keywords:
+        - Zeitstrahl
+        - Chronik
+        - Epoche
+        - Geschichte
+    support:
+        source: https://github.com/Samson1964/contao-timeline-bundle

--- a/meta/schachbulle/contao-timeline-bundle/en.yml
+++ b/meta/schachbulle/contao-timeline-bundle/en.yml
@@ -1,0 +1,14 @@
+en:
+    title: Timeline
+    description: >
+        Presents historical sequences as a timeline. Visitors move through the entries using a navigation bar at the bottom.
+
+        Each entry carries a headline, a text and optionally an image, a video or a quote. A year is enough as a point in time; dates down to the second, periods and a freely chosen label instead of the date are equally possible. Eras group several entries under a single bar.
+
+        The timeline is rendered as a content element or as a front end module in the page layout.
+    keywords:
+        - timeline
+        - chronicle
+        - history
+    support:
+        source: https://github.com/Samson1964/contao-timeline-bundle


### PR DESCRIPTION
Adds German and English metadata for [schachbulle/contao-timeline-bundle](https://packagist.org/packages/schachbulle/contao-timeline-bundle), which integrates a timeline as a content element and a front end module. It runs on Contao 4.13 and Contao 5.

Updated after review: the package has been renamed from `contao-timelinejs-bundle` to `contao-timeline-bundle`, and the descriptions no longer mention the library's product name — so the allowlist stays untouched.