### PR TITLE
Add metadata for three heimseiten extensions

### DIFF
--- a/linter/allowlists/de.txt
+++ b/linter/allowlists/de.txt
@@ -271,6 +271,7 @@ Einwilligungseinstellungen
 Einwilligungsfunktion
 Einzelbestellungen
 Einzelturniere
+Elementgruppe
 Elementsets
 Elternelement
 Elterntabelle
@@ -491,6 +492,7 @@ Key
 Keys
 Keywords
 KI
+Kindansicht
 Klartextwerte
 Klassenbasierte
 Klassensammlung
@@ -817,7 +819,9 @@ Seitenaufruf
 Seitenaufrufe
 Seitenbaum
 Seitenbeschreibung
+Seitenbild
 Seiteneigenschaften
+Seiteneinstellungen
 Seiteninformation
 Seitenlayout
 Seitenlayouts

--- a/linter/allowlists/default.txt
+++ b/linter/allowlists/default.txt
@@ -193,6 +193,7 @@ Fieldset
 fieldset
 file
 Flex
+flexImages
 Flickr
 Flower
 Font
@@ -263,6 +264,7 @@ ID
 id
 IDs
 iFrame
+image
 Immobilienbörse
 ImmobilienScout
 Immobilienscout
@@ -301,6 +303,7 @@ Krebbers
 krpano
 KuteJS
 Labelcenter
+labels
 Labels
 Lamotte
 LASR
@@ -354,6 +357,7 @@ Mimir
 mmenu
 MonitoringSystemSensor
 Monoslideshow
+move
 mpdf
 mPDF
 MultiColumnWizard
@@ -430,6 +434,7 @@ POIs
 PostFinance
 Preload
 preload
+primaryImageOfPage
 Prix
 Prod
 prod

--- a/meta/heimseiten/contao-fleximages-bundle/de.yml
+++ b/meta/heimseiten/contao-fleximages-bundle/de.yml
@@ -1,0 +1,4 @@
+de:
+    title: flexImages-Galerie
+    description: >
+        Erweitert das Inhaltselement Galerie um die Option „flexImages verwenden“. Die Bilder werden dann zeilenweise angeordnet: Innerhalb einer Zeile behalten alle Bilder das Verhältnis von Breite und Höhe, werden auf eine gemeinsame Höhe gebracht und füllen die verfügbare Breite bündig aus. Die Höhe einer Zeile ergibt sich aus dem ersten Bild der Galerie. Der Abstand zwischen den Bildern lässt sich über die CSS-Variable image-gap anpassen. Grundlage ist die Bibliothek flexImages von Pixabay, die lokal mitgeliefert wird.

--- a/meta/heimseiten/contao-fleximages-bundle/en.yml
+++ b/meta/heimseiten/contao-fleximages-bundle/en.yml
@@ -1,0 +1,4 @@
+en:
+    title: flexImages gallery
+    description: >
+        Adds the option “use flexImages” to the gallery content element. The images are then arranged in rows: within a row every image keeps its aspect ratio, is scaled to a common height and the row fills the available width flush to both edges. The row height is derived from the first image of the gallery. The gap between the images can be adjusted with the CSS variable image-gap. It is based on the flexImages library by Pixabay, which is shipped locally.

--- a/meta/heimseiten/contao-form-label-mover-bundle/de.yml
+++ b/meta/heimseiten/contao-form-label-mover-bundle/de.yml
@@ -1,0 +1,4 @@
+de:
+    title: Wandernde Beschriftungen in Formularen
+    description: >
+        Legt die Beschriftung eines Formularfeldes zunächst in das Feld selbst. Sobald das Feld den Fokus erhält oder einen Wert enthält, wandert die Beschriftung animiert an den oberen Rand des Feldes und verkleinert sich, bleibt also dauerhaft lesbar. Aktiviert wird das über die CSS-Klasse move_labels am Formular oder am Modul. Erfasst werden ein- und mehrzeilige Textfelder sowie Felder für Passwörter; automatisch ausgefüllte, bereits vorbelegte und Felder für ein Datum werden dabei ebenfalls berücksichtigt. Der Abstand über dem Feld, der Abstand im Feld und die Farbe der Schrift lassen sich über CSS-Variablen anpassen.

--- a/meta/heimseiten/contao-form-label-mover-bundle/en.yml
+++ b/meta/heimseiten/contao-form-label-mover-bundle/en.yml
@@ -1,0 +1,4 @@
+en:
+    title: Floating form labels
+    description: >
+        Places the label of a form field inside the field itself. As soon as the field receives focus or contains a value, the label moves to the top edge of the field and shrinks, so it remains readable at all times. It is enabled with the CSS class move_labels on the form or on the module. Single-line and multi-line text fields as well as password fields are covered; fields filled in by the browser, fields with an existing value and date fields are taken into account as well. The spacing above the field, the padding inside it and the font colour can be adjusted with CSS variables.

--- a/meta/heimseiten/contao-paste-into-nested-elements-bundle/de.yml
+++ b/meta/heimseiten/contao-paste-into-nested-elements-bundle/de.yml
@@ -1,0 +1,4 @@
+de:
+    title: In verschachtelte Elemente einfügen
+    description: >
+        Ergänzt die Übersicht eines Artikels um einen Knopf, mit dem sich ein Inhaltselement aus der Zwischenablage direkt in eine Elementgruppe einfügen lässt, ohne deren Kindansicht zu öffnen. Der Knopf erscheint an allen Elementen, die Kindelemente aufnehmen — im Kern sind das Elementgruppe, Akkordeon und Slider, ebenso Elemente aus anderen Erweiterungen. Ein Element lässt sich dabei nicht in sich selbst oder in eines seiner Kindelemente verschieben. An der Darstellung der Listen ändert sich nichts. Die Erweiterung stellt eine Funktion von Contao 6 bereits unter Contao 5.7 bereit; eingefügt wird dort am Anfang der Gruppe, weil Contao 5.7 das Anhängen am Ende noch nicht kennt.

--- a/meta/heimseiten/contao-paste-into-nested-elements-bundle/en.yml
+++ b/meta/heimseiten/contao-paste-into-nested-elements-bundle/en.yml
@@ -1,0 +1,4 @@
+en:
+    title: Paste into nested elements
+    description: >
+        Adds a button to the article overview that pastes a content element from the clipboard straight into an element group, without opening its child view first. The button appears on every element that accepts child elements — in the core these are the element group, the accordion and the slider, and elements from other extensions are covered as well. An element cannot be moved into itself or into one of its own children. The appearance of the lists remains unchanged. The extension makes a Contao 6 feature available under Contao 5.7; it pastes at the beginning of the group, because appending at the end is not yet available in Contao 5.7.

--- a/meta/heimseiten/contao-primary-page-image-bundle/de.yml
+++ b/meta/heimseiten/contao-primary-page-image-bundle/de.yml
@@ -1,0 +1,4 @@
+de:
+    title: Seitenbild
+    description: >
+        Ergänzt die Seiteneinstellungen um ein Bild, das als primaryImageOfPage in die strukturierten Daten der Seite geschrieben wird. Damit lässt sich steuern, welches Bild Suchmaschinen der Seite zuordnen. Im Seitenlayout steht das Bild zusätzlich zur Verfügung und lässt sich zum Beispiel im Kopfbereich ausgeben. Die Erweiterung stellt eine Funktion von Contao 6 bereits unter Contao 5.7 bereit und verwendet dasselbe Feld wie der Kern. Ab Contao 6 übernimmt der Kern diese Aufgabe und die Erweiterung hält sich zurück, sodass ein Update ohne Vorarbeit möglich ist und die vorhandenen Daten erhalten bleiben.

--- a/meta/heimseiten/contao-primary-page-image-bundle/en.yml
+++ b/meta/heimseiten/contao-primary-page-image-bundle/en.yml
@@ -1,0 +1,4 @@
+en:
+    title: Page image
+    description: >
+        Adds an image to the page settings, which is written to the structured data of the page as primaryImageOfPage. This controls which image search engines associate with the page. The image is also available in the page layout, for example to display it in the header. The extension makes a Contao 6 feature available under Contao 5.7 and uses the same field as the core. From Contao 6 onwards the core takes over and the extension stays out of the way, so an upgrade needs no preparation and the existing data is kept.


### PR DESCRIPTION
Adds the metadata for three extensions:

- [heimseiten/contao-primary-page-image-bundle](https://packagist.org/packages/heimseiten/contao-primary-page-image-bundle) — backports the page image from Contao 6 (contao/contao#9565) to Contao 5.7
- [heimseiten/contao-form-label-mover-bundle](https://packagist.org/packages/heimseiten/contao-form-label-mover-bundle) — floating labels for form fields
- [heimseiten/contao-fleximages-bundle](https://packagist.org/packages/heimseiten/contao-fleximages-bundle) — row-based gallery layout using flexImages

Seven words are added to the allow lists so the spell checker passes:

| List | Word | Why |
| --- | --- | --- |
| `de.txt` | Seitenbild, Seiteneinstellungen | regular German compound nouns |
| `default.txt` | primaryImageOfPage | the schema.org property written by the first extension |
| `default.txt` | move, labels | from the CSS class `move_labels` (`Labels` is already allowed, the lowercase spelling was missing) |
| `default.txt` | image | from the CSS variable `image-gap` |
| `default.txt` | flexImages | name of the bundled library |

The linter passes locally for all six files.