### PR TITLE
Add metadata for schachbulle/contao-dsbnewsletter-bundle

### DIFF
--- a/meta/schachbulle/contao-dsbnewsletter-bundle/de.yml
+++ b/meta/schachbulle/contao-dsbnewsletter-bundle/de.yml
@@ -1,0 +1,15 @@
+de:
+    title: DSB-Newsletter
+    description: >
+        Erweitert den Newsletter um Inhaltselemente, deren Reihenfolge sich frei festlegen lässt. Ein Newsletter entsteht dadurch aus einzelnen Abschnitten und nicht mehr in einem einzigen Textfeld.
+
+        Jeder Abschnitt trägt eine Überschrift, wahlweise ein Bild und einen Text. Das Bild kann über, unter, links oder rechts vom Text stehen, einen erklärenden Text tragen und auf eine Adresse verweisen. Einzelne Abschnitte lassen sich verbergen, ohne sie zu löschen.
+
+        Die Abschnitte erscheinen dort, wo im Inhalt der Insert-Tag steht. Er wird beim Einschalten von selbst gesetzt und lässt sich frei verschieben.
+    keywords:
+        - Newsletter
+        - Inhaltselement
+        - DSB
+        - Schachbund
+    support:
+        source: https://github.com/Samson1964/contao-dsbnewsletter-bundle

--- a/meta/schachbulle/contao-dsbnewsletter-bundle/en.yml
+++ b/meta/schachbulle/contao-dsbnewsletter-bundle/en.yml
@@ -1,0 +1,15 @@
+en:
+    title: DSB Newsletter
+    description: >
+        Extends the newsletter with content elements that can be put in any order. A newsletter is built from separate sections instead of one single text field.
+
+        Each section carries a headline, an optional image and a text. The image can be placed above, below, left or right of the text, can have a caption and can link to an address. Single sections can be hidden without deleting them.
+
+        The sections appear where the insert tag is placed within the content. It is added automatically when the feature is switched on and can be moved freely.
+    keywords:
+        - newsletter
+        - content element
+        - DSB
+        - chess
+    support:
+        source: https://github.com/Samson1964/contao-dsbnewsletter-bundle


### PR DESCRIPTION
Adds the German and English metadata for `schachbulle/contao-dsbnewsletter-bundle`.

The package is registered on Packagist and extends the Contao newsletter with orderable content elements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)