### PR TITLE
Add metadata for schachbulle/contao-kaderlisten-bundle

### DIFF
--- a/linter/allowlists/de.txt
+++ b/linter/allowlists/de.txt
@@ -469,6 +469,8 @@ Items
 Jobbörse
 Jobletter
 Jobposting
+Kaderlisten
+Kaderstufe
 Kalenderformate
 Kalenderraster
 Kameratyp
@@ -522,6 +524,7 @@ Kreuztabellen
 Kundenrezensionen
 Kundenstimmen
 Kurzlinks
+Landesverband
 Landingpages
 Langtext
 Langtexten
@@ -794,6 +797,7 @@ Röntgenaufnahmen
 Scans
 Schachbund
 Schachbundes
+Schachspielern
 Schachturnier
 Schachturniere
 Schaltfläche
@@ -877,6 +881,7 @@ span
 Speed
 Speisenpläne
 Spiders
+Spielerregister
 Spielersuche
 splitter
 Sportler

--- a/linter/allowlists/default.txt
+++ b/linter/allowlists/default.txt
@@ -162,6 +162,7 @@ Edition
 EFG
 Einzelhandelsgeschäfte
 Elasticsearch
+Elo
 Email
 eMail
 eps

--- a/meta/schachbulle/contao-kaderlisten-bundle/de.yml
+++ b/meta/schachbulle/contao-kaderlisten-bundle/de.yml
@@ -1,0 +1,14 @@
+de:
+    title: Kaderlisten
+    description: >
+        Verwaltet Kaderlisten von Schachspielern und gibt sie als Inhaltselement im Frontend aus. Zu jeder Liste gehören Jahr, Zeitraum und die Spieler mit ihrer Kaderstufe, dem Landesverband, DWZ und Elo.
+
+        Die Spieler werden einmal angelegt und dann in beliebig vielen Listen verwendet; auf Wunsch lassen sie sich mit dem Spielerregister verknüpfen. Die Ausgabe nennt zu jedem Spieler auch seine Kaderstufe im Jahr davor. Welche Stufen erscheinen und ob DWZ und Elo sichtbar sind, legt das Inhaltselement fest.
+    keywords:
+        - Schach
+        - Kader
+        - Kaderliste
+        - Spieler
+        - Liste
+    support:
+        source: https://github.com/Samson1964/contao-kaderlisten-bundle

--- a/meta/schachbulle/contao-kaderlisten-bundle/en.yml
+++ b/meta/schachbulle/contao-kaderlisten-bundle/en.yml
@@ -1,0 +1,13 @@
+en:
+    title: Squad lists
+    description: >
+        Manages squad lists of chess players and outputs them as a content element in the front end. Each list holds a year, a period of validity and the players with their squad level, regional association, DWZ and Elo rating.
+
+        Players are created once and can then be used in any number of lists; they can optionally be linked to the player register. The output also shows each player's squad level from the previous year. Which levels appear and whether DWZ and Elo are visible is set per content element.
+    keywords:
+        - chess
+        - squad
+        - list
+        - players
+    support:
+        source: https://github.com/Samson1964/contao-kaderlisten-bundle


### PR DESCRIPTION
Adds German and English metadata for `schachbulle/contao-kaderlisten-bundle`, an extension that manages squad lists of chess players and outputs them as a content element.

The package is registered on Packagist and its current release is 2.0.0.

The German description uses five compound words the spell checker does not know, so they were added to `linter/allowlists/de.txt`: Kaderlisten, Kaderstufe, Landesverband, Schachspielern, Spielerregister. `Elo` is a proper name used in both languages and was added to `linter/allowlists/default.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)