### PR TITLE
Add metadata for schachbulle/contao-chronik-bundle

### DIFF
--- a/linter/allowlists/de.txt
+++ b/linter/allowlists/de.txt
@@ -797,6 +797,7 @@ Röntgenaufnahmen
 Scans
 Schachbund
 Schachbundes
+Schachchronik
 Schachspielern
 Schachturnier
 Schachturniere
@@ -1026,6 +1027,7 @@ Varone
 Veranstaltungsbuchung
 Veranstaltungsorte
 Veranstaltungssystem
+Vereinsregister
 Verification
 Verkaufsobjekte
 verkaufsstarker

--- a/meta/schachbulle/contao-chronik-bundle/de.yml
+++ b/meta/schachbulle/contao-chronik-bundle/de.yml
@@ -1,0 +1,19 @@
+de:
+    title: Schachchronik
+    description: >
+        Verwaltet eine Chronik und gibt die Ereignisse im Frontend in zeitlicher Reihenfolge aus.
+
+        Zu jedem Ereignis gehören ein Ort, ein Zeitraum, ein Titel, ein Text und eine Quelle mit Adresse. Als Datum genügt eine Jahreszahl; ebenso möglich sind Monat und Tag sowie Zeiträume über mehrere Jahre.
+
+        Ein Menü teilt lange Chroniken in Abschnitte einstellbarer Länge auf, etwa in Jahrzehnte. Personen aus dem Spielerregister erscheinen mit ihrem Namen und führen auf ihre Detailseite; die Vereine stammen aus dem Vereinsregister.
+
+        Ausgegeben wird die Chronik als Frontendmodul im Seitenlayout.
+    keywords:
+        - Chronik
+        - Geschichte
+        - Schach
+        - Verein
+        - Spielerregister
+        - Vereinsregister
+    support:
+        source: https://github.com/Samson1964/contao-chronik-bundle

--- a/meta/schachbulle/contao-chronik-bundle/en.yml
+++ b/meta/schachbulle/contao-chronik-bundle/en.yml
@@ -1,0 +1,17 @@
+en:
+    title: Chess Chronicle
+    description: >
+        Manages a chronicle and renders its events in chronological order in the front end.
+
+        Every event carries a place, a period, a title, a text and a source with its address. A year is enough as a point in time; month and day as well as periods spanning several years are equally possible.
+
+        A menu splits long chronicles into sections of a configurable length, decades for instance. People taken from the player register appear by name and link to their detail page; the clubs come from the club register.
+
+        The chronicle is rendered as a front end module in the page layout.
+    keywords:
+        - chronicle
+        - history
+        - chess
+        - club
+    support:
+        source: https://github.com/Samson1964/contao-chronik-bundle


### PR DESCRIPTION
Adds the German and English metadata for `schachbulle/contao-chronik-bundle`, a Contao extension that manages a chronicle and renders its events in chronological order in the front end.

The package is registered on Packagist: https://packagist.org/packages/schachbulle/contao-chronik-bundle

Two words were added to `linter/allowlists/de.txt`, both inserted alphabetically:

* `Schachchronik` — the German title of the extension
* `Vereinsregister` — the club register the events are linked to (`Spielerregister` is already on the list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
