### PR TITLE
Enhance German description for contao-i18n-duplication

### DIFF
--- a/meta/christianbargon/contao-i18n-duplication/de.yml
+++ b/meta/christianbargon/contao-i18n-duplication/de.yml
@@ -1,7 +1,7 @@
 de:
     title: Inhalte Duplizieren
     description: >
-        Contao-Inhalte mit einem Klick duplizieren. Insert-Tags, Weiterleitungsseiten und Hauptsprache (bei der Verwendung von ChangeLanguage) werden automatisch angepasst. Geeignet für Vorarbeiten zur Übersetzung der Internetseite mit z. B. Contao2xliff.
+        Contao-Inhalte mit einem Klick duplizieren – Seitenbaum, Events, FAQ, Nachrichten, Formulare & Module inkl. aller Inhaltselemente. Neu: Ausgeblendete Inhaltselemente überspringen, Isotope-Unterstützung (Kategorien inkl. Duplizierung & automatischer Kategorie-Zuweisung). Insert-Tags, IDs, Weiterleitungsseiten und Hauptsprache werden automatisch aktualisiert. Ideal als Vorbereitung für Übersetzungen, z. B. mit Contao2xliff.
     keywords:
         - Duplizieren
         - Inhalte
@@ -11,4 +11,6 @@ de:
         - Nachrichten
         - Formulare
         - ChangeLanguage
+        - Isotope
+        - Module
     homepage: https://www.contao2xliff.de/inhalte-duplizieren.html


### PR DESCRIPTION
Adds the new features to the German description (page tree, events, FAQ, news, forms & modules, hidden-element skipping, Isotope support) plus the Isotope / Module keywords.

Replaces #699 – the English side was already merged in #700, and #699's branch had drifted too far from main. This one is branched off current main and passes the linter (Kategoriezuweisung → Kategorie-Zuweisung, so no allow-list change is needed).