### PR TITLE
Add metadata for bluebranch/chatbot

### DIFF
--- a/meta/bluebranch/chatbot/de.yml
+++ b/meta/bluebranch/chatbot/de.yml
@@ -1,0 +1,24 @@
+de:
+    title: BlueBranch Chatbot
+    description: >
+        KI-Chatbot und KI-Suche für Contao: Die Erweiterung übergibt deine Seiteninhalte beim Lauf des Suchindex an eine Chatbot-API und beantwortet Besucherfragen daraus – als Chat-Widget und als Zusammenfassung über der Trefferliste der Suche.
+        Die KI antwortet ausschließlich aus deinen eigenen Inhalten und nennt die verwendeten Seiten als Quelle. Der API-Key bleibt dabei auf dem Server und wird nie an den Browser übertragen.
+
+        Einzelne Seiten und ganze Bereiche kannst du von den Antworten ausnehmen. Ein Modul im Backend zeigt dir, was der Chatbot gelernt hat, und lässt dich Einträge wieder löschen.
+
+        Wie es funktioniert:
+          1. Installation der Erweiterung `$ composer require bluebranch/chatbot` oder über den Contao Manager
+          2. Registriere Dich auf https://chatbot.bluebranch.de und erstelle einen API-Key
+          3. API-Key am Startpunkt der Website hinterlegen und den Suchindex neu aufbauen
+    keywords:
+        - contao
+        - ki
+        - chatbot
+        - suche
+        - assistent
+        - support
+        - faq
+    homepage: https://github.com/BlueBranch-GmbH/chatbot-contao
+    support:
+        issues: https://github.com/BlueBranch-GmbH/chatbot-contao/issues
+        docs: https://github.com/BlueBranch-GmbH/chatbot-contao

--- a/meta/bluebranch/chatbot/de.yml
+++ b/meta/bluebranch/chatbot/de.yml
@@ -6,6 +6,8 @@ de:
 
         Einzelne Seiten und ganze Bereiche kannst du von den Antworten ausnehmen. Ein Modul im Backend zeigt dir, was der Chatbot gelernt hat, und lässt dich Einträge wieder löschen.
 
+        Zum Datenschutz: Die Daten werden ausschließlich in Deutschland verarbeitet, die KI läuft auf eigenen Servern, und deine Inhalte werden nicht zum Training von Modellen genutzt. Ein Vertrag nach Art. 28 DSGVO ist auf Anfrage möglich.
+
         Wie es funktioniert:
           1. Installation der Erweiterung `$ composer require bluebranch/chatbot` oder über den Contao Manager
           2. Registriere Dich auf https://chatbot.bluebranch.de und erstelle einen API-Key

--- a/meta/bluebranch/chatbot/de.yml
+++ b/meta/bluebranch/chatbot/de.yml
@@ -1,7 +1,7 @@
 de:
     title: BlueBranch Chatbot
     description: >
-        KI-Chatbot und KI-Suche für Contao: Die Erweiterung übergibt deine Seiteninhalte beim Lauf des Suchindex an eine Chatbot-API und beantwortet Besucherfragen daraus – als Chat-Widget und als Zusammenfassung über der Trefferliste der Suche.
+        KI-Chatbot und KI-Suche für Contao: Die Erweiterung übergibt die Inhalte deiner Seiten beim Lauf des Suchindex an eine Chatbot-API und beantwortet die Fragen deiner Besucher daraus – als Chat-Widget und als Zusammenfassung über der Trefferliste der Suche.
         Die KI antwortet ausschließlich aus deinen eigenen Inhalten und nennt die verwendeten Seiten als Quelle. Der API-Key bleibt dabei auf dem Server und wird nie an den Browser übertragen.
 
         Einzelne Seiten und ganze Bereiche kannst du von den Antworten ausnehmen. Ein Modul im Backend zeigt dir, was der Chatbot gelernt hat, und lässt dich Einträge wieder löschen.

--- a/meta/bluebranch/chatbot/en.yml
+++ b/meta/bluebranch/chatbot/en.yml
@@ -6,6 +6,8 @@ en:
 
         Single pages and entire sections can be excluded from the answers. A back end module shows you what the chatbot has learned and lets you delete entries again.
 
+        On data protection: all data is processed in Germany only, the AI runs on our own servers, and your content is never used to train models. An agreement under Art. 28 GDPR is available on request.
+
         How it works:
           1. Install the extension via `$ composer require bluebranch/chatbot` or use the Contao Manager
           2. Register at https://chatbot.bluebranch.de and create an API key

--- a/meta/bluebranch/chatbot/en.yml
+++ b/meta/bluebranch/chatbot/en.yml
@@ -1,0 +1,24 @@
+en:
+    title: BlueBranch Chatbot
+    description: >
+        AI chat and AI search for Contao: the extension hands your page content to a chatbot API while the search index is built and answers visitor questions from it – as a chat widget and as a summary above the search results.
+        The AI answers from your own content only and names the pages it used as sources. The API key stays on the server and is never sent to the browser.
+
+        Single pages and entire sections can be excluded from the answers. A back end module shows you what the chatbot has learned and lets you delete entries again.
+
+        How it works:
+          1. Install the extension via `$ composer require bluebranch/chatbot` or use the Contao Manager
+          2. Register at https://chatbot.bluebranch.de and create an API key
+          3. Store the API key on the website root page and rebuild the search index
+    keywords:
+        - contao
+        - ai
+        - chatbot
+        - search
+        - assistant
+        - support
+        - faq
+    homepage: https://github.com/BlueBranch-GmbH/chatbot-contao
+    support:
+        issues: https://github.com/BlueBranch-GmbH/chatbot-contao/issues
+        docs: https://github.com/BlueBranch-GmbH/chatbot-contao


### PR DESCRIPTION
Adds the German and English metadata for `bluebranch/chatbot`, an AI chatbot and AI search extension for Contao 4.13 and 5.x.

The extension passes page content to a chatbot API while the search index is built and answers visitor questions from exactly that content — as a chat widget and as a summary above the Contao search results.

- Source: https://github.com/BlueBranch-GmbH/chatbot-contao
- No package logo added: the vendor logo in `meta/bluebranch/logo.svg` already applies.
- `homepage` is set because the package is not yet published on packagist.org; the linter treats a 404 there as a private package, for which `homepage` is required.

https://claude.ai/code/session_017jM7Bv8aB3zJTmwbTm2QCm