### PR TITLE
Add schachbulle/contao-chessresults-bundle metadata

### DIFF
--- a/linter/allowlists/de.txt
+++ b/linter/allowlists/de.txt
@@ -354,6 +354,7 @@ Formularwidget
 Formvalidation
 formvalidation
 Fortschrittsanzeige
+Fortschrittstabelle
 Fortschrittstabellen
 Fremdschlüssel
 Frontend

--- a/linter/allowlists/default.txt
+++ b/linter/allowlists/default.txt
@@ -82,6 +82,8 @@ ChangeLanguage
 ChangeNewsMore
 chatbot
 Checkbox
+chess
+ChessResults
 Chesstempo
 ChurchDesk
 Claude
@@ -458,6 +460,7 @@ Request
 require
 reset
 REST
+results
 RGAA
 RSCE
 Ritter

--- a/meta/schachbulle/contao-chessresults-bundle/de.yml
+++ b/meta/schachbulle/contao-chessresults-bundle/de.yml
@@ -1,0 +1,17 @@
+de:
+    title: ChessResults
+    description: >
+        Bindet die Tabellen eines Turniers von chess-results.com als Inhaltselement in die eigene Seite ein. Es genügt die Nummer des Turniers aus der Adresse.
+
+        Zur Auswahl stehen die Liste der Teilnehmer nach Namen oder nach Elo-Zahl, die Rangliste nach einer bestimmten Runde, die Fortschrittstabelle und die Paarungen einer Runde. Welche Spalten erscheinen, lässt sich für jedes Element einzeln festlegen.
+
+        Die geholten Daten werden im Element selbst hinterlegt, damit nicht bei jedem Aufruf der Seite eine Abfrage bei ChessResults nötig wird. Unter der Tabelle steht der Zeitpunkt, den ChessResults als letzte Änderung meldet.
+    keywords:
+        - Schach
+        - Turnier
+        - Chess-Results
+        - Turniertabelle
+        - Startrangliste
+        - Fortschrittstabelle
+    support:
+        source: https://github.com/Samson1964/contao-chessresults-bundle

--- a/meta/schachbulle/contao-chessresults-bundle/en.yml
+++ b/meta/schachbulle/contao-chessresults-bundle/en.yml
@@ -1,0 +1,16 @@
+en:
+    title: ChessResults
+    description: >
+        Embeds the tables of a tournament from chess-results.com into your own page as a content element. The tournament number from the address is all it takes.
+
+        Available lists are the players by name or by rating, the standings after a given round, the progress table and the pairings of a round. Which columns appear can be set for each element.
+
+        The retrieved data is kept in the element itself, so that not every page view requires a request to ChessResults. Below the table you see the time that ChessResults reports as the last change.
+    keywords:
+        - chess
+        - tournament
+        - Chess-Results
+        - standings
+        - pairings
+    support:
+        source: https://github.com/Samson1964/contao-chessresults-bundle


### PR DESCRIPTION
Adds German and English metadata for `schachbulle/contao-chessresults-bundle`, a content element that embeds tournament tables from chess-results.com into a Contao page. The package is published on Packagist.

Four allowlist entries are needed for the texts:

* `default.txt`: `chess`, `ChessResults`, `results` — the product name and the parts of the domain `chess-results.com`
* `de.txt`: `Fortschrittstabelle` — the plural `Fortschrittstabellen` was already present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
