### PR TITLE
Add metadata for schachbulle/contao-navigation-bundle

### DIFF
--- a/meta/schachbulle/contao-navigation-bundle/de.yml
+++ b/meta/schachbulle/contao-navigation-bundle/de.yml
@@ -1,0 +1,15 @@
+de:
+    title: Seiten- und Artikel-Navigation
+    description: >
+        Fügt über ein Inserttag eine Navigation über die Artikel einer Seite ein. Aufgeführt werden die veröffentlichten Artikel in ihrer Reihenfolge; der gerade aufgerufene Eintrag steht als Text da, die übrigen als Verweise.
+
+        Der erste Eintrag trägt den Titel der Seite, denn wer die Seite ohne Angabe eines Artikels aufruft, landet beim ersten Artikel. Wahlweise lässt sich auch die Navigation einer anderen Seite einfügen.
+
+        Die Navigation erscheint je Aufruf nur einmal, selbst wenn das Inserttag in mehreren Artikeln der Seite steht.
+    keywords:
+        - Navigation
+        - Seiten
+        - Artikel
+        - Inserttag
+    support:
+        source: https://github.com/Samson1964/contao-navigation-bundle

--- a/meta/schachbulle/contao-navigation-bundle/de.yml
+++ b/meta/schachbulle/contao-navigation-bundle/de.yml
@@ -1,15 +1,16 @@
 de:
     title: Seiten- und Artikel-Navigation
     description: >
-        Fügt über ein InsertTag eine Navigation über die Artikel einer Seite ein. Aufgeführt werden die veröffentlichten Artikel in ihrer Reihenfolge; der gerade aufgerufene Eintrag steht als Text da, die übrigen als Verweise.
+        Stellt zwei InsertTags bereit. Das eine listet die untergeordneten Seiten einer Seite auf, das andere die Artikel einer Seite.
 
-        Der erste Eintrag trägt den Titel der Seite, denn wer die Seite ohne Angabe eines Artikels aufruft, landet beim ersten Artikel. Wahlweise lässt sich auch die Navigation einer anderen Seite einfügen.
+        Aufgeführt wird in der Reihenfolge, die der Seitenbaum vorgibt; der gerade aufgerufene Eintrag steht als Text da, die übrigen als Verweise. Bei Seiten gelten dieselben Regeln wie in der Navigation von Contao: im Menü versteckte, nicht veröffentlichte und geschützte Seiten bleiben draußen.
 
-        Die Navigation erscheint je Aufruf nur einmal, selbst wenn das InsertTag in mehreren Artikeln der Seite steht.
+        Die Ausgabe läuft über ein Template und lässt sich damit frei gestalten.
     keywords:
         - Navigation
         - Seiten
         - Artikel
         - Inserttag
+        - Untermenü
     support:
         source: https://github.com/Samson1964/contao-navigation-bundle

--- a/meta/schachbulle/contao-navigation-bundle/de.yml
+++ b/meta/schachbulle/contao-navigation-bundle/de.yml
@@ -1,11 +1,11 @@
 de:
     title: Seiten- und Artikel-Navigation
     description: >
-        Fügt über ein Inserttag eine Navigation über die Artikel einer Seite ein. Aufgeführt werden die veröffentlichten Artikel in ihrer Reihenfolge; der gerade aufgerufene Eintrag steht als Text da, die übrigen als Verweise.
+        Fügt über ein InsertTag eine Navigation über die Artikel einer Seite ein. Aufgeführt werden die veröffentlichten Artikel in ihrer Reihenfolge; der gerade aufgerufene Eintrag steht als Text da, die übrigen als Verweise.
 
         Der erste Eintrag trägt den Titel der Seite, denn wer die Seite ohne Angabe eines Artikels aufruft, landet beim ersten Artikel. Wahlweise lässt sich auch die Navigation einer anderen Seite einfügen.
 
-        Die Navigation erscheint je Aufruf nur einmal, selbst wenn das Inserttag in mehreren Artikeln der Seite steht.
+        Die Navigation erscheint je Aufruf nur einmal, selbst wenn das InsertTag in mehreren Artikeln der Seite steht.
     keywords:
         - Navigation
         - Seiten

--- a/meta/schachbulle/contao-navigation-bundle/en.yml
+++ b/meta/schachbulle/contao-navigation-bundle/en.yml
@@ -1,15 +1,16 @@
 en:
     title: Page and article navigation
     description: >
-        Adds a navigation across the articles of a page via an insert tag. The published articles are listed in their order; the article currently shown is plain text, the others are links.
+        Provides two insert tags. One lists the subpages of a page, the other one the articles of a page.
 
-        The first entry carries the title of the page, because opening the page without naming an article leads to the first article. Optionally the navigation of a different page can be inserted as well.
+        Entries appear in the order given by the page tree; the entry currently shown is plain text, the others are links. For pages the same rules apply as in the Contao navigation: pages hidden from the menu, unpublished pages and protected pages are left out.
 
-        The navigation appears only once per request, even if the insert tag is placed in several articles of the page.
+        The output runs through a template and can therefore be styled freely.
     keywords:
         - navigation
         - pages
         - articles
         - insert tag
+        - submenu
     support:
         source: https://github.com/Samson1964/contao-navigation-bundle

--- a/meta/schachbulle/contao-navigation-bundle/en.yml
+++ b/meta/schachbulle/contao-navigation-bundle/en.yml
@@ -1,0 +1,15 @@
+en:
+    title: Page and article navigation
+    description: >
+        Adds a navigation across the articles of a page via an insert tag. The published articles are listed in their order; the article currently shown is plain text, the others are links.
+
+        The first entry carries the title of the page, because opening the page without naming an article leads to the first article. Optionally the navigation of a different page can be inserted as well.
+
+        The navigation appears only once per request, even if the insert tag is placed in several articles of the page.
+    keywords:
+        - navigation
+        - pages
+        - articles
+        - insert tag
+    support:
+        source: https://github.com/Samson1964/contao-navigation-bundle


### PR DESCRIPTION
Adds the German and English metadata for [schachbulle/contao-navigation-bundle](https://packagist.org/packages/schachbulle/contao-navigation-bundle).

The extension provides two insert tags: one lists the subpages of a page, the other the articles of a page. Both are rendered through a template that can be overridden. The package is registered on Packagist and currently at version 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)