### PR TITLE
Add metadata for schachbulle/contao-schiedsrichter-bundle

### DIFF
--- a/meta/schachbulle/contao-schiedsrichter-bundle/de.yml
+++ b/meta/schachbulle/contao-schiedsrichter-bundle/de.yml
@@ -1,0 +1,15 @@
+de:
+    title: Schiedsrichter-Lizenzen
+    description: >
+        Verwaltet die Lizenzen der Schiedsrichter im Schach: Stufe, Laufzeit und Verlängerung.
+
+        Die Daten lassen sich aus einer zweiten Datenbank übernehmen. Wer dort schon erfasst ist, wird aktualisiert, wer fehlt, neu aufgenommen; wer nicht mehr auftaucht, bleibt erhalten und wird nur verborgen.
+
+        Ein Frontendmodul gibt alle Schiedsrichter mit gültiger Lizenz als Tabelle aus. Auf Wunsch pflegt die Erweiterung zusätzlich einen Newsletter mit ihren Adressen.
+    keywords:
+        - Schiedsrichter
+        - Lizenz
+        - Schach
+        - DSB
+    support:
+        source: https://github.com/Samson1964/contao-schiedsrichter-bundle

--- a/meta/schachbulle/contao-schiedsrichter-bundle/en.yml
+++ b/meta/schachbulle/contao-schiedsrichter-bundle/en.yml
@@ -1,0 +1,14 @@
+en:
+    title: Referee Licenses
+    description: >
+        Manages the licenses of chess referees: level, term and renewal.
+
+        The records can be taken over from a second database. Anyone already on file is updated, anyone missing is added; anyone who no longer appears there is kept and merely hidden.
+
+        A front end module lists all referees holding a valid license as a table. On request the extension also maintains a newsletter with their addresses.
+    keywords:
+        - referee
+        - license
+        - chess
+    support:
+        source: https://github.com/Samson1964/contao-schiedsrichter-bundle


### PR DESCRIPTION
Adds German and English metadata for `schachbulle/contao-schiedsrichter-bundle`.

The extension manages the licenses of chess referees (level, term and renewal), can take the records over from a second database, and lists the referees holding a valid license through a front end module.

The package has been on Packagist since 2020; the current release is 2.0.0, which supports Contao 4.13 and Contao 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
